### PR TITLE
fix fetching of version string from pkg_resources

### DIFF
--- a/web3/__init__.py
+++ b/web3/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import pkg_resources
 
-__version__ = pkg_resources.get_distribution("web3").version
+__version__ = pkg_resources.get_distribution("web3.py").version


### PR DESCRIPTION
### What was wrong?

The package name was not correct so the version string couldn't be extracted in the `web3/__init__.py` file.

### How was it fixed?

Fixed it to be `web3.py`

#### Cute Animal Picture

![59808 ngsversion 1422035361936 adapt 768 1](https://cloud.githubusercontent.com/assets/824194/14564640/bd0aa7b2-02e4-11e6-8fb7-6a06125453d8.jpg)

