### PR TITLE
fix sha3 being in the wrong location

### DIFF
--- a/tests/utilities/test_sha3.py
+++ b/tests/utilities/test_sha3.py
@@ -36,5 +36,5 @@ import web3
     )
 )
 def test_sha3(value, expected, encoding):
-    actual = web3.web3.sha3(value, encoding=encoding)
+    actual = web3.sha3(value, encoding=encoding)
     assert expected == actual

--- a/web3/__init__.py
+++ b/web3/__init__.py
@@ -4,7 +4,9 @@ import pkg_resources
 
 from . import (
     eth,
-    web3,
+)
+from .utils.crypto import (
+    sha3,
 )
 
 __version__ = pkg_resources.get_distribution("web3.py").version
@@ -12,5 +14,5 @@ __version__ = pkg_resources.get_distribution("web3.py").version
 __all__ = [
     "__version__",
     "eth",
-    "web3",
+    "sha3",
 ]

--- a/web3/web3/__init__.py
+++ b/web3/web3/__init__.py
@@ -1,3 +1,0 @@
-from web3.utils.crypto import (  # noqa
-    sha3
-)


### PR DESCRIPTION
the `sha3` function was in the wrong spot.  Moved it from `web3.web3.sha3` to `web3.sha3`
