### PR TITLE
Rename package to just web3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ readme = open(os.path.join(DIR, 'README.md')).read()
 
 
 setup(
-    name='web3.py',
+    name='web3',
     version='0.1.0',
     description="""Web3.py""",
     long_description=readme,

--- a/web3/__init__.py
+++ b/web3/__init__.py
@@ -1,0 +1,9 @@
+from __future__ import absolute_import
+
+import pkg_resources
+
+__version__ = pkg_resources.get_distribution("web3").version
+
+__all__ = [
+    "__version__",
+]


### PR DESCRIPTION
### What was wrong?

The package was named `web3.py` which meant people would have to type `pip install web3.py`.  It's a nicer experience to say `pip install web3`

### How was it fixed?

Changed the package name

#### Cute Animal Picture

![15_12_15 baby gorilla-9](https://cloud.githubusercontent.com/assets/824194/14723287/80a977ba-07cd-11e6-9b69-bb8dd91eec28.jpg)
