### PR TITLE
Add missing python dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,8 @@ setup(
         "six>=1.10.0",
         "pysha3>=0.3",
         "requests>=2.10.0",
+        "rlp>=0.4.6",
+        "gevent>=1.1.1",
     ],
     py_modules=['web3'],
     license="MIT",


### PR DESCRIPTION
### What was wrong?

The project was missing the `rlp` and `gevent` dependencies.

### How was it fixed?

Added them in `setup.py

#### Cute Animal Picture

> put a cute animal picture here.

![f3b68c3732480809358f3fb1a58eb32e](https://cloud.githubusercontent.com/assets/824194/16811873/a522c19a-48e7-11e6-8853-a89e301f4847.jpg)
