### PR TITLE
Added test and patch to support addresses as constructor args.

### DIFF
--- a/tests/contracts/conftest.py
+++ b/tests/contracts/conftest.py
@@ -155,3 +155,43 @@ def WithConstructorArgumentsContract(web3_tester,
         code_runtime=WITH_CONSTRUCTOR_ARGUMENTS_RUNTIME,
         source=WITH_CONSTRUCTOR_ARGUMENTS_SOURCE,
     )
+
+
+CONTRACT_WITH_CONSTRUCTOR_ADDRESS_SOURCE = "contract WithAddrArg { address testAddr; function WithAddrArg(address _testAddr){ testAddr = _testAddr; }}"
+CONTRACT_WITH_CONSTRUCTOR_ADDRESS_CODE = b"0x60606040526040516020806063833981016040528080519060200190919050505b80600060006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908302179055505b50600a8060596000396000f360606040526008565b00"
+CONTRACT_WITH_CONSTRUCTOR_ADDRESS_RUNTIME = b"0x60606040526008565b00"
+CONTRACT_WITH_CONSTRUCTOR_ADDRESS_ABI = json.loads('[{"inputs":[{"name":"_testAddr","type":"address"}],"type":"constructor"}]')
+
+
+@pytest.fixture()
+def WITH_CONSTRUCTOR_ADDRESS_SOURCE():
+    return CONTRACT_WITH_CONSTRUCTOR_ADDRESS_SOURCE
+
+
+@pytest.fixture()
+def WITH_CONSTRUCTOR_ADDRESS_CODE():
+    return CONTRACT_WITH_CONSTRUCTOR_ADDRESS_CODE
+
+
+@pytest.fixture()
+def WITH_CONSTRUCTOR_ADDRESS_RUNTIME():
+    return CONTRACT_WITH_CONSTRUCTOR_ADDRESS_RUNTIME
+
+
+@pytest.fixture()
+def WITH_CONSTRUCTOR_ADDRESS_ABI():
+    return CONTRACT_WITH_CONSTRUCTOR_ADDRESS_ABI
+
+
+@pytest.fixture()
+def WithConstructorAddressArgumentsContract(web3_tester,
+                                     WITH_CONSTRUCTOR_ADDRESS_SOURCE,
+                                     WITH_CONSTRUCTOR_ADDRESS_CODE,
+                                     WITH_CONSTRUCTOR_ADDRESS_RUNTIME,
+                                     WITH_CONSTRUCTOR_ADDRESS_ABI):
+    return web3_tester.eth.contract(
+        abi=WITH_CONSTRUCTOR_ADDRESS_ABI,
+        code=WITH_CONSTRUCTOR_ADDRESS_CODE,
+        code_runtime=WITH_CONSTRUCTOR_ADDRESS_RUNTIME,
+        source=WITH_CONSTRUCTOR_ADDRESS_SOURCE,
+    )

--- a/tests/contracts/test_contract_deployment.py
+++ b/tests/contracts/test_contract_deployment.py
@@ -43,3 +43,18 @@ def test_contract_deployment_with_constructor_with_arguments(web3_tester,
 
     blockchain_code = web3_tester.eth.getCode(contract_address)
     assert force_bytes(blockchain_code) == force_bytes(WITH_CONSTRUCTOR_ARGUMENTS_RUNTIME)
+
+
+def test_contract_deployment_with_constructor_with_address_argument(web3_tester,
+                                                                    WithConstructorAddressArgumentsContract,
+                                                                    WITH_CONSTRUCTOR_ADDRESS_RUNTIME):
+    deploy_txn = WithConstructorAddressArgumentsContract.deploy(arguments=["0x16d9983245de15e7a9a73bc586e01ff6e08de737"])
+
+    txn_receipt = web3_tester.eth.getTransactionReceipt(deploy_txn)
+    assert txn_receipt is not None
+
+    assert txn_receipt['contractAddress']
+    contract_address = txn_receipt['contractAddress']
+
+    blockchain_code = web3_tester.eth.getCode(contract_address)
+    assert force_bytes(blockchain_code) == force_bytes(WITH_CONSTRUCTOR_ADDRESS_RUNTIME)

--- a/web3/utils/abi.py
+++ b/web3/utils/abi.py
@@ -78,6 +78,12 @@ def is_encodable(_type, value):
 
         max_length = int(sub)
         return len(value) <= max_length
+    elif base == 'address':
+        if not is_string(value):
+            return False
+        if len(value) != 42:
+            return False
+        return True
     else:
         raise ValueError("Unsupported type")
 

--- a/web3/utils/abi.py
+++ b/web3/utils/abi.py
@@ -13,6 +13,9 @@ from .types import (
     is_integer,
     is_boolean,
 )
+from .address import (
+    is_address,
+)
 
 
 def filter_by_type(_type, contract_abi):
@@ -79,9 +82,7 @@ def is_encodable(_type, value):
         max_length = int(sub)
         return len(value) <= max_length
     elif base == 'address':
-        if not is_string(value):
-            return False
-        if len(value) != 42:
+        if not is_address(value):
             return False
         return True
     else:

--- a/web3/utils/address.py
+++ b/web3/utils/address.py
@@ -29,6 +29,7 @@ def is_address(address):
     if not is_string(address):
         return False
 
+    address = force_text(address)  # python3 requires both re.match arguments to be the same type
     if not re.match(r"^(0x)?[0-9a-fA-F]{40}$", address):
         return False
     elif re.match(r"^(0x)?[0-9a-f]{40}", address) or re.match(r"(0x)?[0-9A-F]{40}$", address):


### PR DESCRIPTION
### What was wrong?

Addresses could not be used as constructor arguments

### How was it fixed?

Added relevant code to `utils/abi.py` to check the address type (was omitted).
Also wrote relevant tests (basically copying what was written for other contracts)

#### Cute Animal Picture

![SoCute!](https://s-media-cache-ak0.pinimg.com/564x/88/01/9d/88019d0173e46ce1d099ca5a6a415313.jpg)

