### PR TITLE
adjust text coersion for is_address

### DIFF
--- a/web3/utils/address.py
+++ b/web3/utils/address.py
@@ -11,6 +11,7 @@ from .encoding import (
 )
 from .string import (
     force_text,
+    coerce_args_to_text,
 )
 from .types import (
     is_string,
@@ -21,6 +22,7 @@ from .formatting import (
 )
 
 
+@coerce_args_to_text
 def is_address(address):
     """
     Checks if the given string is an address
@@ -29,7 +31,6 @@ def is_address(address):
     if not is_string(address):
         return False
 
-    address = force_text(address)  # python3 requires both re.match arguments to be the same type
     if not re.match(r"^(0x)?[0-9a-fA-F]{40}$", address):
         return False
     elif re.match(r"^(0x)?[0-9a-f]{40}", address) or re.match(r"(0x)?[0-9A-F]{40}$", address):

--- a/web3/utils/string.py
+++ b/web3/utils/string.py
@@ -76,6 +76,15 @@ def coerce_args_to_bytes(fn):
     return inner
 
 
+def coerce_args_to_text(fn):
+    @functools.wraps(fn)
+    def inner(*args, **kwargs):
+        text_args = force_obj_to_text(args)
+        text_kwargs = force_obj_to_text(kwargs)
+        return fn(*text_args, **text_kwargs)
+    return inner
+
+
 def coerce_return_to_bytes(fn):
     @functools.wraps(fn)
     def inner(*args, **kwargs):


### PR DESCRIPTION
### What was wrong?

The manner in which the `address` argument was being coerced to text in the `is_address` helper wasn't ideal.

### How was it fixed?

adjusted it to use the decorator pattern found elsewhere (as well as implementing the appropriate decorator)

#### Cute Animal Picture

> put a cute animal picture here.

![babypanda_b](https://cloud.githubusercontent.com/assets/824194/17164942/c8f3f830-5389-11e6-93a3-2f3dde8e5262.jpg)
