### PR TITLE
pygeth fix

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -5,7 +5,7 @@ import shutil
 
 # This has to go here so that the `gevent.monkey.patch_all()` happens in the
 # main thread.
-from pygeth import (
+from geth import (
     LoggingMixin,
     DevGethProcess,
 )


### PR DESCRIPTION
### What was wrong?

`pygeth` is now `geth`

### How was it fixed?

changed import to `geth`

#### Cute Animal Picture

> put a cute animal picture here.

![67662 adapt 768 1](https://cloud.githubusercontent.com/assets/824194/17273068/8abe9668-5665-11e6-8168-205f19ae382b.jpg)
