### PR TITLE
Piper/geth fixes

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -128,13 +128,12 @@ def setup_rpc_provider():
     from web3.providers.rpc import RPCProvider
 
     with tempdir() as base_dir:
-        geth = GethProcess('testing', base_dir=base_dir)
-        geth.start()
-        wait_for_http_connection(geth.rpc_port)
-        provider = RPCProvider(port=geth.rpc_port)
-        provider._geth = geth
-        yield provider
-        geth.stop()
+        with GethProcess('testing', base_dir=base_dir) as geth:
+            geth.wait_for_rpc(30)
+            geth.wait_for_dag(600)
+            provider = RPCProvider(port=geth.rpc_port)
+            provider._geth = geth
+            yield provider
 
 
 @contextlib.contextmanager
@@ -142,13 +141,12 @@ def setup_ipc_provider():
     from web3.providers.ipc import IPCProvider
 
     with tempdir() as base_dir:
-        geth = GethProcess('testing', base_dir=base_dir)
-        geth.start()
-        wait_for_ipc_connection(geth.ipc_path)
-        provider = IPCProvider(geth.ipc_path)
-        provider._geth = geth
-        yield provider
-        geth.stop()
+        with GethProcess('testing', base_dir=base_dir) as geth:
+            geth.wait_for_ipc(30)
+            geth.wait_for_dag(600)
+            provider = IPCProvider(geth.ipc_path)
+            provider._geth = geth
+            yield provider
 
 
 @pytest.yield_fixture(params=[

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
+addopts= -v
 python_paths= .

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ pytest>=2.8.2
 pytest-pythonpath>=0.3
 tox>=1.8.0
 eth-testrpc==0.4.2
-py-geth>=0.5.0
+py-geth>=0.6.0
 # Until pyethereum > 1.3.6 is released.
 https://github.com/ethereum/pyethereum/tarball/b06829e56e2a3de5276077a611ed8813b6cf5e74
 secp256k1>=0.12.0

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -363,7 +363,11 @@ def transact_with_contract_function(contract=None,
 
     .. code-block:: python
 
-        def withdraw(self, to_address: str, amount_in_eth: Decimal, from_account=None, max_gas=50000) -> str:
+        def withdraw(self,
+                     to_address: str,
+                     amount_in_eth: Decimal,
+                     from_account=None,
+                     max_gas=50000) -> str:
             '''Withdraw funds from a wallet contract.
 
             :param amount_in_eth: How much as ETH
@@ -387,7 +391,9 @@ def transact_with_contract_function(contract=None,
             }
 
             # Interact with underlying wrapped contract
-            txid = transact_with_contract_function(self.contract, "withdraw", tx_info, to_address, wei)
+            txid = transact_with_contract_function(
+                self.contract, "withdraw", tx_info, to_address, wei,
+            )
             return txid
 
     The transaction is created in the Ethereum node memory pool.
@@ -396,11 +402,11 @@ def transact_with_contract_function(contract=None,
 
     :param contract: :class:`web3.contract.Contract` object instance
     :param function_name: Contract function name to call
-    :param transaction: Dictionary of transaction parameters to pass to underlying ``web3.eth.sendTransaction``
+    :param transaction: Dictionary of transaction parameters to pass to
+                        underlying ``web3.eth.sendTransaction``
     :param *arguments: Arguments to be passed to contract function. Automatically encoded
     :return: String, 0x formatted transaction hash.
     """
-
 
     if not arguments:
         arguments = []


### PR DESCRIPTION
### What was wrong?

The py-geth usage was outdated.

### How was it fixed?

Update how geth is being used to use the new context manager interface and wait functions.

#### Cute Animal Picture

> put a cute animal picture here.

![vgt7e8zl](https://cloud.githubusercontent.com/assets/824194/17277315/5548536e-56fd-11e6-9aec-0fb63c715089.jpg)
