### PR TITLE
Piper/miner and txn pool interfaces

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -2,6 +2,9 @@ import pytest
 import contextlib
 import tempfile
 import shutil
+import random
+
+import gevent
 
 # This has to go here so that the `gevent.monkey.patch_all()` happens in the
 # main thread.
@@ -42,17 +45,13 @@ def wait_for_http_connection(port, timeout=30):
             raise ValueError("Unable to establish HTTP connection")
 
 
-def wait_for_ipc_connection(ipc_path, timeout=30):
-    import os
-    import gevent
-
-    with gevent.Timeout(timeout):
-        while True:
-            if os.path.exists(ipc_path):
-                break
-            gevent.sleep(0.1)
-        else:
-            raise ValueError("Unable to establish HTTP connection")
+@pytest.fixture()
+def wait_for_miner_start():
+    def _wait_for_miner_start(web3, timeout=30):
+        with gevent.Timeout(timeout):
+            while not web3.eth.mining or not web3.eth.hashrate:
+                gevent.sleep(random.random())
+    return _wait_for_miner_start
 
 
 @pytest.fixture()

--- a/tests/eth-module/test_iban.py
+++ b/tests/eth-module/test_iban.py
@@ -10,8 +10,8 @@ import pytest
         ),
     )
 )
-def test_createIndirect(value, expected, web3):
-    actual = web3.eth.iban.createIndirect(value).toString()
+def test_createIndirect(value, expected, web3_tester):
+    actual = web3_tester.eth.iban.createIndirect(value).toString()
     assert actual == expected
 
 
@@ -40,8 +40,8 @@ def test_createIndirect(value, expected, web3):
         ),
     ),
 )
-def test_fromAddress(value, expected, web3):
-    actual = web3.eth.iban.fromAddress(value).toString()
+def test_fromAddress(value, expected, web3_tester):
+    actual = web3_tester.eth.iban.fromAddress(value).toString()
     assert actual == expected
 
 
@@ -118,11 +118,11 @@ def test_fromAddress(value, expected, web3):
         ),
     ),
 )
-def test_isValid(value, expected, web3):
-    actual = web3.eth.iban.isValid(value)
+def test_isValid(value, expected, web3_tester):
+    actual = web3_tester.eth.iban.isValid(value)
     assert actual is expected
 
-    iban = web3.eth.iban(value)
+    iban = web3_tester.eth.iban(value)
     assert iban.isValid() is expected
 
 
@@ -136,6 +136,6 @@ def test_isValid(value, expected, web3):
         ),
     )
 )
-def test_toAddress(value, expected, web3):
-    actual = web3.eth.iban(value).address()
+def test_toAddress(value, expected, web3_tester):
+    actual = web3_tester.eth.iban(value).address()
     assert actual == expected

--- a/tests/mining/conftest.py
+++ b/tests/mining/conftest.py
@@ -11,4 +11,5 @@ def skip_testrpc_and_wait_for_mining_start(web3, wait_for_miner_start):
     wait_for_miner_start(web3)
 
     assert web3.eth.mining
+    assert web3.eth.hashrate
     assert web3.miner.hashrate

--- a/tests/mining/conftest.py
+++ b/tests/mining/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+
+from web3.providers.rpc import TestRPCProvider
+
+
+@pytest.fixture(autouse=True)
+def skip_testrpc_and_wait_for_mining_start(web3, wait_for_miner_start):
+    if isinstance(web3.currentProvider, TestRPCProvider):
+        pytest.skip("No miner interface on eth-testrpc")
+
+    wait_for_miner_start(web3)
+
+    assert web3.eth.mining
+    assert web3.miner.hashrate

--- a/tests/mining/test_miner_hashrate.py
+++ b/tests/mining/test_miner_hashrate.py
@@ -1,0 +1,6 @@
+from web3.providers.rpc import TestRPCProvider
+
+
+def test_miner_hashrate(web3, wait_for_miner_start):
+    hashrate = web3.miner.hashrate
+    assert hashrate > 0

--- a/tests/mining/test_miner_setExtra.py
+++ b/tests/mining/test_miner_setExtra.py
@@ -1,0 +1,27 @@
+import random
+
+import gevent
+
+from web3.utils.encoding import decode_hex
+
+
+def test_miner_setExtra(web3, wait_for_block):
+    initial_extra = decode_hex(web3.eth.getBlock(web3.eth.blockNumber)['extraData'])
+
+    new_extra_data = b'-this-is-32-bytes-of-extra-data-'
+
+    # sanity
+    assert initial_extra != new_extra_data
+
+    web3.miner.setExtra(new_extra_data)
+
+    with gevent.Timeout(30):
+        while True:
+            extra_data = decode_hex(web3.eth.getBlock(web3.eth.blockNumber)['extraData'])
+            if extra_data == new_extra_data:
+                break
+            gevent.sleep(random.random())
+
+    after_extra = decode_hex(web3.eth.getBlock(web3.eth.blockNumber)['extraData'])
+
+    assert after_extra == new_extra_data

--- a/tests/mining/test_miner_setGasPrice.py
+++ b/tests/mining/test_miner_setGasPrice.py
@@ -1,0 +1,12 @@
+def test_miner_setGasPrice(web3, wait_for_block):
+    initial_gas_price = web3.eth.gasPrice
+
+    # sanity check
+    assert web3.eth.gasPrice > 1000
+
+    web3.miner.setGasPrice(initial_gas_price // 2)
+
+    wait_for_block(web3, web3.eth.blockNumber + 2, timeout=60)
+
+    after_gas_price = web3.eth.gasPrice
+    assert after_gas_price < initial_gas_price

--- a/tests/mining/test_miner_start.py
+++ b/tests/mining/test_miner_start.py
@@ -1,0 +1,25 @@
+import random
+
+import gevent
+
+
+def test_miner_start(web3, wait_for_miner_start):
+    # sanity
+    assert web3.eth.mining
+    assert web3.miner.hashrate
+
+    web3.miner.stop()
+
+    with gevent.Timeout(30):
+        while web3.eth.mining or web3.eth.hashrate:
+            gevent.sleep(random.random())
+
+    assert not web3.eth.mining
+    assert not web3.miner.hashrate
+
+    web3.miner.start(1)
+
+    wait_for_miner_start(web3)
+
+    assert web3.eth.mining
+    assert web3.miner.hashrate

--- a/tests/mining/test_miner_stop.py
+++ b/tests/mining/test_miner_stop.py
@@ -1,0 +1,18 @@
+import random
+
+import gevent
+
+
+def test_miner_stop(web3):
+    # sanity
+    assert web3.eth.mining
+    assert web3.miner.hashrate
+
+    web3.miner.stop()
+
+    with gevent.Timeout(30):
+        while web3.eth.mining or web3.eth.hashrate:
+            gevent.sleep(random.random())
+
+    assert not web3.eth.mining
+    assert not web3.miner.hashrate

--- a/tests/txpool-module/conftest.py
+++ b/tests/txpool-module/conftest.py
@@ -11,4 +11,5 @@ def skip_testrpc_and_wait_for_mining_start(web3, wait_for_miner_start):
     wait_for_miner_start(web3)
 
     assert web3.eth.mining
+    assert web3.eth.hashrate
     assert web3.miner.hashrate

--- a/tests/txpool-module/conftest.py
+++ b/tests/txpool-module/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+
+from web3.providers.rpc import TestRPCProvider
+
+
+@pytest.fixture(autouse=True)
+def skip_testrpc_and_wait_for_mining_start(web3, wait_for_miner_start):
+    if isinstance(web3.currentProvider, TestRPCProvider):
+        pytest.skip("No miner interface on eth-testrpc")
+
+    wait_for_miner_start(web3)
+
+    assert web3.eth.mining
+    assert web3.miner.hashrate

--- a/tests/txpool-module/test_txpool_content.py
+++ b/tests/txpool-module/test_txpool_content.py
@@ -1,0 +1,37 @@
+import random
+import gevent
+
+
+def test_txpool_content(web3):
+    web3.miner.stop()
+
+    with gevent.Timeout(30):
+        while web3.miner.hashrate or web3.eth.mining:
+            gevent.sleep(random.random())
+
+    txn_1_hash = web3.eth.sendTransaction({
+        'from': web3.eth.coinbase,
+        'to': '0xd3cda913deb6f67967b99d67acdfa1712c293601',
+        'value': 12345,
+    })
+    txn_1 = web3.eth.getTransaction(txn_1_hash)
+    txn_2_hash = web3.eth.sendTransaction({
+        'from': web3.eth.coinbase,
+        'to': '0xd3cda913deb6f67967b99d67acdfa1712c293601',
+        'value': 54321,
+    })
+    txn_2 = web3.eth.getTransaction(txn_2_hash)
+
+    content = web3.txpool.content
+
+    assert web3.eth.coinbase in content['pending']
+
+    pending_txns = content['pending'][web3.eth.coinbase]
+
+    assert txn_1['nonce'] in pending_txns
+    assert txn_2['nonce'] in pending_txns
+
+    assert pending_txns[txn_1['nonce']][0]['hash'] == txn_1_hash
+    assert pending_txns[txn_1['nonce']][0]['value'] == 12345
+    assert pending_txns[txn_2['nonce']][0]['hash'] == txn_2_hash
+    assert pending_txns[txn_2['nonce']][0]['value'] == 54321

--- a/tests/txpool-module/test_txpool_inspect.py
+++ b/tests/txpool-module/test_txpool_inspect.py
@@ -1,0 +1,44 @@
+import random
+import gevent
+
+
+def test_txpool_inspect(web3):
+    """
+    TODO: How can this test be modified to be different from the test for `txpool_content`
+    """
+    web3.miner.stop()
+
+    with gevent.Timeout(30):
+        while web3.miner.hashrate or web3.eth.mining:
+            gevent.sleep(random.random())
+
+    txn_1_hash = web3.eth.sendTransaction({
+        'from': web3.eth.coinbase,
+        'to': '0xd3cda913deb6f67967b99d67acdfa1712c293601',
+        'value': 12345,
+    })
+    txn_1 = web3.eth.getTransaction(txn_1_hash)
+    txn_2_hash = web3.eth.sendTransaction({
+        'from': web3.eth.coinbase,
+        'to': '0xd3cda913deb6f67967b99d67acdfa1712c293601',
+        'value': 54321,
+    })
+    txn_2 = web3.eth.getTransaction(txn_2_hash)
+
+    inspect_content = web3.txpool.inspect
+
+    assert web3.eth.coinbase in inspect_content['pending']
+
+    pending_txns = inspect_content['pending'][web3.eth.coinbase]
+
+    assert txn_1['nonce'] in pending_txns
+    assert txn_2['nonce'] in pending_txns
+
+    txn_1_summary = pending_txns[txn_1['nonce']][0]
+    txn_2_summary = pending_txns[txn_2['nonce']][0]
+
+    assert '0xd3cda913deb6f67967b99d67acdfa1712c293601' in txn_1_summary
+    assert '12345 wei' in txn_1_summary
+
+    assert '0xd3cda913deb6f67967b99d67acdfa1712c293601' in txn_2_summary
+    assert '54321 wei' in txn_2_summary

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -65,6 +65,7 @@ class Eth(object):
         raise NotImplementedError("Async calling has not been implemented")
 
     @property
+    @apply_formatters_to_return(to_decimal)
     def hashrate(self):
         return self.request_manager.request_blocking("eth_hashrate", [])
 

--- a/web3/formatters.py
+++ b/web3/formatters.py
@@ -235,3 +235,28 @@ def outputSyncingFormatter(result):
     result["highestBlock"] = to_decimal(result["highestBlock"])
 
     return result
+
+
+def transaction_pool_formatter(value, txn_formatter):
+    return {
+        'pending': {
+            sender: {
+                to_decimal(nonce): [txn_formatter(txn) for txn in txns]
+                for nonce, txns in txns_by_sender.items()
+            } for sender, txns_by_sender in value.get('pending', {}).items()
+        },
+        'queued': {
+            sender: {
+                to_decimal(nonce): [txn_formatter(txn) for txn in txns]
+                for nonce, txns in txns_by_sender.items()
+            } for sender, txns_by_sender in value.get('queued', {}).items()
+        },
+    }
+
+
+def transaction_pool_content_formatter(value):
+    return transaction_pool_formatter(value, output_transaction_formatter)
+
+
+def transaction_pool_inspect_formatter(value):
+    return transaction_pool_formatter(value, identity)

--- a/web3/main.py
+++ b/web3/main.py
@@ -6,6 +6,8 @@ from web3.shh import Shh
 from web3.net import Net
 from web3.personal import Personal
 from web3.version import Version
+from web3.txpool import TxPool
+from web3.miner import Miner
 
 from web3.providers.rpc import (
     RPCProvider,
@@ -50,6 +52,8 @@ class Web3(object):
         self.net = Net(self._requestManager)
         self.personal = Personal(self._requestManager)
         self.version = Version(self._requestManager)
+        self.txpool = TxPool(self._requestManager)
+        self.miner = Miner(self._requestManager)
 
         self.providers = {
             'RPCProvider': RPCProvider,

--- a/web3/miner.py
+++ b/web3/miner.py
@@ -1,0 +1,37 @@
+from web3.utils.functional import (
+    apply_formatters_to_return,
+)
+from web3.utils.encoding import (
+    to_decimal,
+)
+
+
+class Miner(object):
+    def __init__(self, request_manager):
+        self.request_manager = request_manager
+
+    @property
+    @apply_formatters_to_return(to_decimal)
+    def hashrate(self):
+        return self.request_manager.request_blocking("eth_hashrate", [])
+
+    def makeDAG(self, number):
+        return self.request_manager.request_blocking("miner_makeDag", [number])
+
+    def setExtra(self, extra):
+        return self.request_manager.request_blocking("miner_setExtra", [extra])
+
+    def setGasPrice(self, gas_price):
+        return self.request_manager.request_blocking("miner_setGasPrice", [gas_price])
+
+    def start(self, num_threads):
+        return self.request_manager.request_blocking("miner_start", [num_threads])
+
+    def stop(self):
+        return self.request_manager.request_blocking("miner_stop", [])
+
+    def startAutoDAG(self):
+        return self.request_manager.request_blocking("miner_startAutoDag", [])
+
+    def stopAutoDAG(self):
+        return self.request_manager.request_blocking("miner_stopAutoDag", [])

--- a/web3/txpool.py
+++ b/web3/txpool.py
@@ -1,0 +1,26 @@
+from web3.utils.functional import (
+    apply_formatters_to_return,
+)
+from web3.formatters import (
+    transaction_pool_content_formatter,
+    transaction_pool_inspect_formatter,
+)
+
+
+class TxPool(object):
+    def __init__(self, request_manager):
+        self.request_manager = request_manager
+
+    @property
+    @apply_formatters_to_return(transaction_pool_content_formatter)
+    def content(self):
+        return self.request_manager.request_blocking("txpool_content", [])
+
+    @property
+    @apply_formatters_to_return(transaction_pool_inspect_formatter)
+    def inspect(self):
+        return self.request_manager.request_blocking("txpool_inspect", [])
+
+    @property
+    def status(self):
+        return self.request_manager.request_blocking("txpool_status", [])


### PR DESCRIPTION
This is based on #41 

### What was wrong?

The `web3.miner` and `web3.txpool` interfaces were missing.

### How was it fixed?

Added them according to the management api specificationf or geth

#### Cute Animal Picture

> put a cute animal picture here.

![baby](https://cloud.githubusercontent.com/assets/824194/17277337/df1904a8-56fd-11e6-8c89-cb1f8b104242.jpg)
