### PR TITLE
fix hang on wait_for_block with TestRPCProvider

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -57,12 +57,15 @@ def wait_for_miner_start():
 @pytest.fixture()
 def wait_for_block():
     import gevent
+    from web3.providers.rpc import TestRPCProvider
 
     def _wait_for_block(web3, block_number=1, timeout=60 * 10):
         with gevent.Timeout(timeout):
             while True:
                 if web3.eth.blockNumber >= block_number:
                     break
+                if isinstance(web3.currentProvider, TestRPCProvider):
+                    web3._requestManager.request_blocking("evm_mine", [])
                 gevent.sleep(1)
     return _wait_for_block
 


### PR DESCRIPTION
### What was wrong?

The `wait_for_block` fixture will hang if used with the `TestRPCProvider'

### How was it fixed?

Added a conditional to force new blocks to be mined while waiting so that the blockchain will advance.

#### Cute Animal Picture

> put a cute animal picture here.

![killdeer-007_jc](https://cloud.githubusercontent.com/assets/824194/17370388/1dd4d9da-5959-11e6-9229-b04f8fa1a495.jpg)
