### PR TITLE
Format syncing return values

### DIFF
--- a/web3/eth.py
+++ b/web3/eth.py
@@ -48,6 +48,7 @@ class Eth(object):
         raise NotImplementedError()
 
     @property
+    @apply_formatters_to_return(formatters.syncing_formatter)
     def syncing(self):
         return self.request_manager.request_blocking("eth_syncing", [])
 

--- a/web3/formatters.py
+++ b/web3/formatters.py
@@ -252,3 +252,19 @@ def transaction_pool_content_formatter(value):
 
 def transaction_pool_inspect_formatter(value):
     return transaction_pool_formatter(value, identity)
+
+
+def syncing_formatter(value):
+    if not value:
+        return value
+
+    formatters = {
+        'startingBlock': to_decimal,
+        'currentBlock': to_decimal,
+        'highestBlock': to_decimal,
+    }
+
+    return {
+        key: formatters.get(key, identity)(value)
+        for key, value in value.items()
+    }


### PR DESCRIPTION
### What was wrong?

The return value from `web3.eth.syncing` was not being formatted

### How was it fixed?

Created a formatter for it and applied it.

#### Cute Animal Picture

> put a cute animal picture here.

![020_dog-shaming](https://cloud.githubusercontent.com/assets/824194/17641684/b9e77144-60e7-11e6-9708-0bdb0751fa4a.jpg)
