### PR TITLE
fix top level module imports

### DIFF
--- a/web3/__init__.py
+++ b/web3/__init__.py
@@ -4,14 +4,18 @@ import pkg_resources
 
 
 from web3.main import Web3  # NOQA
-from web3.providers.rpc import RPCProvider  # NOQA
+from web3.providers.rpc import (  # NOQA
+    RPCProvider,
+    TestRPCProvider,
+)
 from web3.providers.ipc import IPCProvider  # NOQA
 
 __version__ = pkg_resources.get_distribution("web3").version
 
 __all__ = [
     "__version__",
-    "web3",
+    "Web3",
     "RPCProvider",
+    "TestRPCProvider",
     "IPCProvider",
 ]


### PR DESCRIPTION
### What was wrong?

The `README` suggested that `from web3 import TestRPCProvider` should work, when actually it isn't available form there.

### How was it fixed?

I added `TestRPCProvider` to the things that can be imported from the top level `web3` module.

#### Cute Animal Picture


![dog-toys](https://cloud.githubusercontent.com/assets/824194/17669584/6f61aa5a-62cb-11e6-9969-cc3dc29ab935.jpg)
