### PR TITLE
fix to_wei to return an integer

### DIFF
--- a/web3/utils/currency.py
+++ b/web3/utils/currency.py
@@ -76,4 +76,4 @@ def to_wei(number, unit):
     if result_value < MIN_WEI or result_value > MAX_WEI:
         raise ValueError("Resulting wei value must be between 1 and 2**256 - 1")
 
-    return result_value
+    return int(result_value)


### PR DESCRIPTION
### What was wrong?

The `web3.toWei` function was returning a `decimal.Decimal` value which could not be json encoded.

### How was it fixed?

Due to the nature of `toWei`, the resulting value will always be an integer since there are no lower denominations.  Because of this, the return value is now cast to an integer.

#### Cute Animal Picture

![62cefdred](https://cloud.githubusercontent.com/assets/824194/17671957/e7259e60-62d6-11e6-9a3c-de7dcab38f25.jpg)
