### PR TITLE
content type headers

### DIFF
--- a/web3/providers/rpc.py
+++ b/web3/providers/rpc.py
@@ -10,6 +10,7 @@ class RPCProvider(BaseProvider):
         self.host = host
         self.port = port
         self.session = requests.session()
+        self.session.headers.update({'content-type': 'application/json'})
 
         super(RPCProvider, self).__init__(*args, **kwargs)
 


### PR DESCRIPTION
### What was wrong?

RPC requests were not being sent with the appropriate content type.

### How was it fixed?

Added a content-type header set to `application/json` to the request.

#### Cute Animal Picture

![dog_with_bone](https://cloud.githubusercontent.com/assets/824194/17672669/b330e200-62da-11e6-9bdd-cef03c8e26bb.jpg)
