### PR TITLE
fix missing python3 JSONDecodeError

### DIFF
--- a/web3/providers/ipc.py
+++ b/web3/providers/ipc.py
@@ -5,6 +5,11 @@ import os
 import contextlib
 import json
 
+try:
+    from json import JSONDecodeError
+except ImportError:
+    JSONDecodeError = ValueError
+
 import gevent
 from gevent import socket
 from gevent import threading
@@ -94,7 +99,7 @@ class IPCProvider(BaseProvider):
                     else:
                         try:
                             json.loads(force_text(response_raw))
-                        except json.JSONDecodeError:
+                        except JSONDecodeError:
                             continue
                         else:
                             break


### PR DESCRIPTION
### What was wrong?

`json.JSONDecodeError` doesn't exist in python2.7

### How was it fixed?

Aliased `ValueError` to `JSONDecodeError` if the import fails.

#### Cute Animal Picture

![dog-toy-mouth](https://cloud.githubusercontent.com/assets/824194/17687317/381d59fc-6331-11e6-9cbd-b2bf650b1eef.jpg)

