### PR TITLE
Remove implicit gevent.

### DIFF
--- a/web3/providers/rpc.py
+++ b/web3/providers/rpc.py
@@ -1,11 +1,3 @@
-import gevent
-from gevent import monkey
-
-
-monkey.patch_socket()
-monkey.patch_select()
-
-
 from .base import BaseProvider  # noqa: E402
 
 import requests  # noqa: E402


### PR DESCRIPTION
### What was wrong?

Using web3.py in the same Python interpreter as other stuff causes Python interpreter to hang.

### How was it fixed?

Never do implicit gevent. 
