### PR TITLE
cast RPCProvider port to integer

### DIFF
--- a/web3/providers/rpc.py
+++ b/web3/providers/rpc.py
@@ -9,7 +9,7 @@ from .base import BaseProvider  # noqa: E402
 class RPCProvider(BaseProvider):
     def __init__(self, host="127.0.0.1", port="8545", *args, **kwargs):
         self.host = host
-        self.port = port
+        self.port = int(port)
 
         super(RPCProvider, self).__init__(*args, **kwargs)
 


### PR DESCRIPTION
### What was wrong?

`geventhttpclient` fails when passed a port number in the form of a unicode string.

### How was it fixed?

Cast the `port` to an integer when it's passed into the provider.

#### Cute Animal Picture

![Cute animal picture]()

![cat-with-parrot-sleeping-bird-picture](https://cloud.githubusercontent.com/assets/824194/18137446/971e1d66-6f65-11e6-8c00-cb41d3f474a7.jpg)
