### PR TITLE
Fix past log filters and pull in downstream filter fixes

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,8 @@
 pytest>=2.8.2
 pytest-pythonpath>=0.3
 tox>=1.8.0
-eth-testrpc>=0.8.0
-ethereum-tester-client>=1.0.0
+eth-testrpc>=0.8.2
+ethereum-tester-client>=1.1.1
 py-geth>=1.2.0
 ethereum>=1.5.2
 secp256k1>=0.13.1

--- a/tests/filtering/conftest.py
+++ b/tests/filtering/conftest.py
@@ -9,7 +9,6 @@ assert sha3_256(b'').hexdigest() == 'c5d2460186f7233c927e7db2dcc703c0e500b653ca8
 @pytest.fixture(autouse=True)
 def skip_testrpc_and_wait_for_mining_start(web3_empty, wait_for_block,
                                            skip_if_testrpc):
-    skip_if_testrpc(web3_empty)  # TODO: enable testrpc
     wait_for_block(web3_empty)
 
 

--- a/tests/filtering/conftest.py
+++ b/tests/filtering/conftest.py
@@ -7,8 +7,7 @@ assert sha3_256(b'').hexdigest() == 'c5d2460186f7233c927e7db2dcc703c0e500b653ca8
 
 
 @pytest.fixture(autouse=True)
-def skip_testrpc_and_wait_for_mining_start(web3_empty, wait_for_block,
-                                           skip_if_testrpc):
+def wait_for_mining_start(web3_empty, wait_for_block):
     wait_for_block(web3_empty)
 
 

--- a/tests/filtering/test_contract_past_event_filtering.py
+++ b/tests/filtering/test_contract_past_event_filtering.py
@@ -3,7 +3,7 @@ import gevent
 from flaky import flaky
 
 
-@flaky(max_runs=3)
+#@flaky(max_runs=3)
 def test_past_events_filter_with_only_event_name(web3_empty,
                                                  emitter,
                                                  wait_for_transaction,

--- a/tests/filtering/test_contract_past_event_filtering.py
+++ b/tests/filtering/test_contract_past_event_filtering.py
@@ -3,7 +3,7 @@ import gevent
 from flaky import flaky
 
 
-#@flaky(max_runs=3)
+@flaky(max_runs=3)
 def test_past_events_filter_with_only_event_name(web3_empty,
                                                  emitter,
                                                  wait_for_transaction,

--- a/tests/filtering/test_filter_against_latest_blocks.py
+++ b/tests/filtering/test_filter_against_latest_blocks.py
@@ -4,8 +4,9 @@ from flaky import flaky
 
 
 @flaky(max_runs=3)
-def test_filter_against_latest_blocks(web3_empty, wait_for_block):
+def test_filter_against_latest_blocks(web3_empty, wait_for_block, skip_if_testrpc):
     web3 = web3_empty
+    skip_if_testrpc(web3)
 
     seen_blocks = []
     txn_filter = web3.eth.filter("latest")

--- a/tests/filtering/test_filter_against_pending_transactions.py
+++ b/tests/filtering/test_filter_against_pending_transactions.py
@@ -4,8 +4,11 @@ from flaky import flaky
 
 
 @flaky(max_runs=3)
-def test_filter_against_pending_transactions(web3_empty, wait_for_transaction):
+def test_filter_against_pending_transactions(web3_empty,
+                                             wait_for_transaction,
+                                             skip_if_testrpc):
     web3 = web3_empty
+    skip_if_testrpc(web3)
 
     seen_txns = []
     txn_filter = web3.eth.filter("pending")

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -41,6 +41,7 @@ from web3.utils.transactions import (
 )
 from web3.utils.filters import (
     construct_event_filter_params,
+    PastLogFilter,
 )
 
 
@@ -426,12 +427,18 @@ class Contract(object):
         )
 
         log_filter = self.web3.eth.filter(filter_params)
-        log_filter.set_data_filters(data_filter_set)
+
+        past_log_filter = PastLogFilter(
+            web3=log_filter.web3,
+            filter_id=log_filter.filter_id,
+        )
+        past_log_filter.callbacks.extend(log_filter.callbacks)
+        past_log_filter.set_data_filters(data_filter_set)
 
         if callbacks:
-            log_filter.watch(*callbacks)
+            past_log_filter.watch(*callbacks)
 
-        return log_filter
+        return past_log_filter
 
     def estimateGas(self, transaction=None):
         """


### PR DESCRIPTION
### What was wrong?

* There was an error in `eth-testrpc` and `ethereum-tester-client` for the filters code.
* The way `Contract.pastEvents` was implemented caused it to call filter callbacks multiple times with the same log entries.

### How was it fixed?

* Updated version for `eth-testrpc` and `ethereum-tester-client`
* Added a new filter class for `PastLogFilter` to handle historical filters.

#### Cute Animal Picture

![catwithbirdmy31](https://cloud.githubusercontent.com/assets/824194/18212962/2b6baeea-7103-11e6-99fa-81fd53995ba9.jpg)
