### PR TITLE
Allow kwargs when interacting with contract functions

### DIFF
--- a/tests/contracts/test_args_and_kwargs_merger.py
+++ b/tests/contracts/test_args_and_kwargs_merger.py
@@ -1,0 +1,30 @@
+import pytest
+
+from web3.contract import (
+    merge_args_and_kwargs,
+)
+
+
+FUNCTION_ABI = {
+    "constant": False
+    ,"inputs": [
+        {"name":"a", "type":"int256"},
+        {"name":"b", "type":"int256"},
+        {"name":"c", "type":"int256"},
+        {"name":"d", "type":"int256"},
+    ],
+    "name": "testFn",
+    "outputs": [],
+    "type":"function",
+}
+
+
+@pytest.mark.parametrize(
+    'args,kwargs,expected_args',
+    (
+        ([1, 4, 2, 3], {}, [1, 4, 2, 3]),
+    ),
+)
+def test_merging_of_args_and_kwargs(args, kwargs, expected_args):
+    actual_args = merge_args_and_kwargs(FUNCTION_ABI, args, kwargs)
+    assert actual_args == expected_args

--- a/tests/contracts/test_args_and_kwargs_merger.py
+++ b/tests/contracts/test_args_and_kwargs_merger.py
@@ -1,6 +1,6 @@
 import pytest
 
-from web3.contract import (
+from web3.utils.abi import (
     merge_args_and_kwargs,
 )
 
@@ -13,6 +13,15 @@ FUNCTION_ABI = {
         {"name":"c", "type":"int256"},
         {"name":"d", "type":"int256"},
     ],
+    "name": "testFn",
+    "outputs": [],
+    "type":"function",
+}
+
+
+NO_INPUTS_FUNCTION_ABI = {
+    "constant": False
+    ,"inputs": [],
     "name": "testFn",
     "outputs": [],
     "type":"function",
@@ -32,3 +41,8 @@ FUNCTION_ABI = {
 def test_merging_of_args_and_kwargs(args, kwargs, expected_args):
     actual_args = merge_args_and_kwargs(FUNCTION_ABI, args, kwargs)
     assert actual_args == expected_args
+
+
+def test_merging_of_args_and_kwargs_with_no_inputs():
+    actual = merge_args_and_kwargs(NO_INPUTS_FUNCTION_ABI, tuple(), {})
+    assert actual == tuple()

--- a/tests/contracts/test_args_and_kwargs_merger.py
+++ b/tests/contracts/test_args_and_kwargs_merger.py
@@ -22,7 +22,11 @@ FUNCTION_ABI = {
 @pytest.mark.parametrize(
     'args,kwargs,expected_args',
     (
-        ([1, 4, 2, 3], {}, [1, 4, 2, 3]),
+        ((1, 4, 2, 3), {}, (1, 4, 2, 3)),
+        ((1, 4, 2), {'d': 3}, (1, 4, 2, 3)),
+        ((1, 4), {'d': 3, 'c': 2}, (1, 4, 2, 3)),
+        ((1,), {'d': 3, 'b': 4, 'c': 2}, (1, 4, 2, 3)),
+        (tuple(), {'d': 3, 'b': 4, 'a': 1, 'c': 2}, (1, 4, 2, 3)),
     ),
 )
 def test_merging_of_args_and_kwargs(args, kwargs, expected_args):

--- a/tests/contracts/test_contract_call_interface.py
+++ b/tests/contracts/test_contract_call_interface.py
@@ -47,8 +47,16 @@ def test_call_with_one_argument(math_contract):
     assert result == 21
 
 
-def test_call_with_multiple_arguments(math_contract):
-    result = math_contract.call().add(9, 7)
+@pytest.mark.parametrize(
+    'call_args,call_kwargs',
+    (
+        ((9, 7), {}),
+        ((9,), {'b': 7}),
+        (tuple(), {'a': 9, 'b': 7}),
+    ),
+)
+def test_call_with_multiple_arguments(math_contract, call_args, call_kwargs):
+    result = math_contract.call().add(*call_args, **call_kwargs)
     assert result == 16
 
 

--- a/tests/contracts/test_contract_transact_interface.py
+++ b/tests/contracts/test_contract_transact_interface.py
@@ -48,10 +48,13 @@ def test_transacting_with_contract_no_arguments(web3_tester, math_contract):
         (tuple(), {'amt': 5}),
     ),
 )
-def test_transacting_with_contract_with_arguments(web3_tester, math_contract):
+def test_transacting_with_contract_with_arguments(web3_tester,
+                                                  math_contract,
+                                                  transact_args,
+                                                  transact_kwargs):
     initial_value = math_contract.call().counter()
 
-    txn_hash = math_contract.transact().increment(5)
+    txn_hash = math_contract.transact().increment(*transact_args, **transact_kwargs)
     txn_receipt = web3_tester.eth.getTransactionReceipt(txn_hash)
     assert txn_receipt is not None
 

--- a/tests/contracts/test_contract_transact_interface.py
+++ b/tests/contracts/test_contract_transact_interface.py
@@ -41,6 +41,13 @@ def test_transacting_with_contract_no_arguments(web3_tester, math_contract):
     assert final_value - initial_value == 1
 
 
+@pytest.mark.parametrize(
+    'transact_args,transact_kwargs',
+    (
+        ((5,), {}),
+        (tuple(), {'amt': 5}),
+    ),
+)
 def test_transacting_with_contract_with_arguments(web3_tester, math_contract):
     initial_value = math_contract.call().counter()
 

--- a/tests/filtering/test_contract_on_event_filtering.py
+++ b/tests/filtering/test_contract_on_event_filtering.py
@@ -100,7 +100,7 @@ def test_on_filter_with_event_name_and_single_argument(web3_empty,
         wait_for_transaction(web3, txn_hash)
 
     with gevent.Timeout(5):
-        while not seen_logs:
+        while len(seen_logs) < 2:
             gevent.sleep(random.random())
 
     filter.stop_watching(10)

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -280,7 +280,12 @@ class Contract(object):
         if fn_name:
             filters.append(functools.partial(filter_by_name, fn_name))
 
-        if args is not None and kwargs is not None:
+        if args is not None or kwargs is not None:
+            if args is None:
+                args = tuple()
+            if kwargs is None:
+                kwargs = {}
+
             num_arguments = len(args) + len(kwargs)
             filters.extend([
                 functools.partial(filter_by_argument_count, num_arguments),

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -1,7 +1,7 @@
 """Interaction with smart contracts over Web3 connector.
 
 """
-
+import itertools
 import functools
 
 from eth_abi import (
@@ -879,8 +879,8 @@ def merge_args_and_kwargs(function_abi, args, kwargs):
 
     sorted_args = list(zip(
         *sorted(
-            kwargs.items(),
+            itertools.chain(kwargs.items(), args_as_kwargs.items()),
             key=lambda kv: sorted_arg_names.index(kv[0])
         )
-    ))[0]
-    return sorted_args
+    ))
+    return sorted_args[1]

--- a/web3/utils/currency.py
+++ b/web3/utils/currency.py
@@ -31,6 +31,9 @@ units = {
 }
 
 
+denoms = type('denoms', (object,), units)
+
+
 MIN_WEI = 0
 MAX_WEI = 2 ** 256 - 1
 


### PR DESCRIPTION
### What was wrong?

Contract functions could not be called with keyword arguments.

### How was it fixed?

Added some wizardry to allow it.

#### Cute Animal Picture


![il_570xn 504431072_p4kg](https://cloud.githubusercontent.com/assets/824194/18257679/e4fedbce-7384-11e6-9ac2-e6dbea5cc1e4.jpg)

