### PR TITLE
Always estimate gas for transactions with data

### DIFF
--- a/tests/contracts/test_contract_transact_interface.py
+++ b/tests/contracts/test_contract_transact_interface.py
@@ -143,4 +143,4 @@ def test_auto_gas_computation_when_transacting(web3,
     assert force_bytes(final_value) == force_bytes("ÄLÄMÖLÖ")
 
     txn = web3.eth.getTransaction(txn_hash)
-    assert txn['gas'] == gas_estimate + string_contract.gas_buffer
+    assert txn['gas'] == gas_estimate + 100000

--- a/tests/eth-module/test_eth_sendTransaction.py
+++ b/tests/eth-module/test_eth_sendTransaction.py
@@ -38,3 +38,17 @@ def test_eth_sendTransaction_with_data(web3, wait_for_transaction, MATH_CODE, MA
     contract_address = txn_receipt['contractAddress']
 
     assert force_bytes(web3.eth.getCode(contract_address)) == MATH_RUNTIME
+
+
+def test_eth_sendTransaction_auto_estimates_gas_if_not_provided(web3, wait_for_transaction, MATH_CODE, MATH_RUNTIME):
+    txn_hash = web3.eth.sendTransaction({
+        "from": web3.eth.coinbase,
+        "data": MATH_CODE,
+    })
+
+    wait_for_transaction(web3, txn_hash)
+
+    txn_receipt = web3.eth.getTransactionReceipt(txn_hash)
+    contract_address = txn_receipt['contractAddress']
+
+    assert force_bytes(web3.eth.getCode(contract_address)) == MATH_RUNTIME

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -12,6 +12,9 @@ from web3.utils.types import (
 from web3.utils.functional import (
     apply_formatters_to_return,
 )
+from web3.utils.transactions import (
+    get_buffered_gas_estimate,
+)
 from web3.utils.filters import (
     BlockFilter,
     TransactionFilter,
@@ -204,6 +207,11 @@ class Eth(object):
 
     def sendTransaction(self, transaction):
         formatted_transaction = formatters.input_transaction_formatter(self, transaction)
+        if 'gas' not in formatted_transaction and 'data' in formatted_transaction:
+            formatted_transaction['gas'] = get_buffered_gas_estimate(
+                self.web3,
+                transaction=formatted_transaction,
+            )
 
         return self.request_manager.request_blocking(
             "eth_sendTransaction",

--- a/web3/utils/transactions.py
+++ b/web3/utils/transactions.py
@@ -17,3 +17,20 @@ def get_block_gas_limit(web3, block_identifier=None):
         block_identifier = web3.eth.blockNumber
     block = web3.eth.getBlock(block_identifier)
     return block['gasLimit']
+
+
+def get_buffered_gas_estimate(web3, transaction, gas_buffer=100000):
+    gas_estimate_transaction = dict(**transaction)
+
+    gas_estimate = web3.eth.estimateGas(gas_estimate_transaction)
+
+    gas_limit = get_block_gas_limit(web3)
+
+    if gas_estimate > gas_limit:
+        raise ValueError(
+            "Contract does not appear to be delpoyable within the "
+            "current network gas limits.  Estimated: {0}. Current gas "
+            "limit: {1}".format(gas_estimate, gas_limit)
+        )
+
+    return min(gas_limit, gas_estimate + gas_buffer)


### PR DESCRIPTION
### What was wrong?

Only contracts did automatic gas estimates for transactions when really any transaction that includes `data` should automatically have it's gas estimated.

### How was it fixed?

Moved the buffered gas estimation from the contract up into the `eth.sendTransaction` method.

#### Cute Animal Picture

![cat-kills-bird](https://cloud.githubusercontent.com/assets/824194/18284372/e93bb5f2-7426-11e6-867a-5e2359644cdf.jpg)
