### PR TITLE
Fix address[] return types

### DIFF
--- a/tests/contracts/test_normalization_of_return_types.py
+++ b/tests/contracts/test_normalization_of_return_types.py
@@ -1,0 +1,35 @@
+import pytest
+
+from eth_abi import encode_single
+from web3.utils.abi import normalize_return_type
+
+
+@pytest.mark.parametrize(
+    'data_type,data_value,expected_value',
+    (
+        (
+            'bytes32',
+            'arst\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
+            'arst\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
+        ),
+        (
+            'address',
+            'd3cda913deb6f67967b99d67acdfa1712c293601',
+            '0xd3cda913deb6f67967b99d67acdfa1712c293601',
+        ),
+        (
+            'address[]',
+            [
+                'd3cda913deb6f67967b99d67acdfa1712c293601',
+                'bb9bc244d798123fde783fcc1c72d3bb8c189413',
+            ],
+            [
+                '0xd3cda913deb6f67967b99d67acdfa1712c293601',
+                '0xbb9bc244d798123fde783fcc1c72d3bb8c189413',
+            ],
+        ),
+    )
+)
+def test_normalizing_return_values(data_type, data_value, expected_value):
+    actual_value = normalize_return_type(data_type, data_value)
+    assert actual_value == expected_value

--- a/tests/utilities/test_construct_event_data_set.py
+++ b/tests/utilities/test_construct_event_data_set.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-from web3.utils.abi import (
+from web3.utils.events import (
     construct_event_data_set,
 )
 

--- a/tests/utilities/test_construct_event_topics.py
+++ b/tests/utilities/test_construct_event_topics.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-from web3.utils.abi import (
+from web3.utils.events import (
     construct_event_topic_set,
 )
 

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -35,6 +35,7 @@ from web3.utils.abi import (
     check_if_arguments_can_be_encoded,
     function_abi_to_4byte_selector,
     merge_args_and_kwargs,
+    normalize_return_type,
 )
 from web3.utils.decorators import (
     combomethod,
@@ -642,10 +643,11 @@ def call_contract_function(contract,
     output_data = decode_abi(output_types, return_data)
 
     normalized_data = [
-        add_0x_prefix(data_value) if data_type == 'address' else data_value
+        normalize_return_type(data_type, data_value)
         for data_type, data_value
         in zip(output_types, output_data)
     ]
+
     if len(normalized_data) == 1:
         return normalized_data[0]
     else:

--- a/web3/utils/events.py
+++ b/web3/utils/events.py
@@ -19,6 +19,7 @@ from .abi import (
     get_indexed_event_inputs,
     exclude_indexed_event_inputs,
     event_abi_to_log_topic,
+    normalize_return_type,
 )
 
 
@@ -119,6 +120,7 @@ def coerce_event_abi_types_for_decoding(input_types):
     ]
 
 
+@coerce_return_to_text
 def get_event_data(event_abi, log_entry):
     """
     Given an event ABI and a log entry for that event, return the decoded
@@ -155,15 +157,26 @@ def get_event_data(event_abi, log_entry):
         )
 
     decoded_log_data = decode_abi(log_data_types, log_data)
+    normalized_log_data = [
+        normalize_return_type(data_type, data_value)
+        for data_type, data_value
+        in zip(log_data_types, decoded_log_data)
+    ]
+
     decoded_topic_data = [
         decode_single(topic_type, topic_data)
         for topic_type, topic_data
         in zip(log_topic_types, log_topics)
     ]
+    normalized_topic_data = [
+        normalize_return_type(data_type, data_value)
+        for data_type, data_value
+        in zip(log_topic_types, decoded_topic_data)
+    ]
 
     event_args = dict(itertools.chain(
-        zip(log_topic_names, decoded_topic_data),
-        zip(log_data_names, decoded_log_data),
+        zip(log_topic_names, normalized_topic_data),
+        zip(log_data_names, normalized_log_data),
     ))
 
     event_data = {

--- a/web3/utils/filters.py
+++ b/web3/utils/filters.py
@@ -6,7 +6,7 @@ from .types import (
     is_string,
     is_array,
 )
-from .abi import (
+from .events import (
     construct_event_topic_set,
     construct_event_data_set,
 )


### PR DESCRIPTION
### What was wrong?

#70 

Solidity functions which return type `address[]` were not returning addresses with `0x` prefixes.

### How was it fixed?

Added a generic return value normalizer that recursively normalizes return types.

#### Cute Animal Picture

![10-signs-that-your-cat-is-a-wizard-1-805-1363644760-0_big](https://cloud.githubusercontent.com/assets/824194/18291114/8d6ad60a-7443-11e6-9183-bcdd8302e584.jpg)

