### PR TITLE
Quiet testrpc server wsgi logger

### DIFF
--- a/web3/providers/rpc.py
+++ b/web3/providers/rpc.py
@@ -1,6 +1,7 @@
 import contextlib
 import gevent
 from geventhttpclient import HTTPClient
+import logging
 
 
 from .base import BaseProvider  # noqa: E402
@@ -51,11 +52,18 @@ class TestRPCProvider(RPCProvider):
         from testrpc.server import application
         from testrpc.testrpc import evm_reset
 
+        try:
+            logger = kwargs.pop('logger')
+        except KeyError:
+            logger = logging.getLogger('testrpc')
+
         evm_reset()
 
         self.server = WSGIServer(
             (host, port),
             application,
+            log=logger,
+            error_log=logger,
         )
 
         self.thread = gevent.spawn(self.server.serve_forever)


### PR DESCRIPTION
### What was wrong?

The `TestRPCProvider` uses `gevent.pywsgi.WSGIHandler` which defaults to writing all logs to `stdout` and `stderr`.  This is extremely noisy and the log entries are not very helpful.

### How was it fixed?

Changed to use it's own logger if one is not provided.

#### Cute Animal Picture


![tumblr_lf5mria6d31qgsvaco1_400](https://cloud.githubusercontent.com/assets/824194/18293174/6819470a-744e-11e6-862e-9be346db9891.jpg)
