### PR TITLE
Fix eth methods that use `latest/earliest/pending`

### DIFF
--- a/tests/eth-module/test_eth_getBlock.py
+++ b/tests/eth-module/test_eth_getBlock.py
@@ -45,3 +45,14 @@ def test_eth_getBlock_by_hash_with_full_transactions(web3):
     assert block_1_by_hash['number'] == 1
     assert block_1_by_hash['hash'] == block_1_hash
     assert all(isinstance(txn, dict) for txn in block_1['transactions'])
+
+
+def test_eth_getBlock_using_latest(web3):
+    assert web3.eth.blockNumber >= 1
+
+    current_block_number = web3.eth.blockNumber
+
+    block = web3.eth.getBlock('latest')
+    block_number = block['number']
+
+    assert block_number >= current_block_number

--- a/tests/eth-module/test_eth_getBlock.py
+++ b/tests/eth-module/test_eth_getBlock.py
@@ -9,7 +9,6 @@ def wait_for_first_block(web3, wait_for_block):
 
 
 def test_eth_getBlock_by_number(web3):
-    assert web3.eth.blockNumber >= 1
     block_1 = web3.eth.getBlock(1)
     assert block_1
     assert block_1['number'] == 1
@@ -17,7 +16,6 @@ def test_eth_getBlock_by_number(web3):
 
 
 def test_eth_getBlock_by_hash(web3):
-    assert web3.eth.blockNumber >= 1
     block_1 = web3.eth.getBlock(1)
     block_1_hash = block_1['hash']
 
@@ -29,14 +27,12 @@ def test_eth_getBlock_by_hash(web3):
 
 
 def test_eth_getBlock_by_number_with_full_transactions(web3):
-    assert web3.eth.blockNumber >= 1
     block_1 = web3.eth.getBlock(1, True)
     assert block_1['number'] == 1
     assert all(isinstance(txn, dict) for txn in block_1['transactions'])
 
 
 def test_eth_getBlock_by_hash_with_full_transactions(web3):
-    assert web3.eth.blockNumber >= 1
     block_1 = web3.eth.getBlock(1, True)
     block_1_hash = block_1['hash']
 
@@ -48,11 +44,20 @@ def test_eth_getBlock_by_hash_with_full_transactions(web3):
 
 
 def test_eth_getBlock_using_latest(web3):
-    assert web3.eth.blockNumber >= 1
-
     current_block_number = web3.eth.blockNumber
 
     block = web3.eth.getBlock('latest')
     block_number = block['number']
 
     assert block_number >= current_block_number
+
+
+def test_eth_getBlock_using_earliest(web3):
+    current_block_number = web3.eth.blockNumber
+
+    block = web3.eth.getBlock('earliest')
+
+    assert block['number'] == 0
+
+    block_1 = web3.eth.getBlock(0)
+    assert block == block_1

--- a/tests/utilities/test_is_predefined_block_number.py
+++ b/tests/utilities/test_is_predefined_block_number.py
@@ -1,0 +1,20 @@
+import pytest
+
+from web3.utils.blocks import (
+    is_predefined_block_number,
+)
+
+
+@pytest.mark.parametrize(
+    'block_identifier,expected',
+    (
+        ('earliest', True),
+        ('latest', True),
+        ('pending', True),
+        (1, False),
+        ('0x1', False),
+    ),
+)
+def test_is_predefined_block_number(block_identifier, expected):
+    actual = is_predefined_block_number(block_identifier)
+    assert actual is expected

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -20,6 +20,9 @@ from web3.utils.filters import (
     TransactionFilter,
     LogFilter,
 )
+from web3.utils.blocks import (
+    is_predefined_block_number,
+)
 from web3.contract import construct_contract_class
 
 
@@ -138,7 +141,7 @@ class Eth(object):
         `eth_getBlockByHash`
         `eth_getBlockByNumber`
         """
-        if is_integer(block_identifier):
+        if is_predefined_block_number(block_identifier) or is_integer(block_identifier):
             method = 'eth_getBlockByNumber'
         else:
             method = 'eth_getBlockByHash'

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -157,7 +157,7 @@ class Eth(object):
         `eth_getBlockTransactionCountByHash`
         `eth_getBlockTransactionCountByNumber`
         """
-        if is_integer(block_identifier):
+        if is_predefined_block_number(block_identifier) or is_integer(block_identifier):
             method = 'eth_getBlockTransactionCountByNumber'
         else:
             method = 'eth_getBlockTransactionCountByHash'
@@ -183,7 +183,7 @@ class Eth(object):
         `eth_getTransactionByBlockHashAndIndex`
         `eth_getTransactionByBlockNumberAndIndex`
         """
-        if is_integer(block_identifier):
+        if is_predefined_block_number(block_identifier) or is_integer(block_identifier):
             method = 'eth_getTransactionByBlockNumberAndIndex'
         else:
             method = 'eth_getTransactionByBlockHashAndIndex'

--- a/web3/formatters.py
+++ b/web3/formatters.py
@@ -66,20 +66,6 @@ def apply_to_array(formatter_fn):
     )
 
 
-def isPredefinedBlockNumber(blockNumber):
-    if not is_string(blockNumber):
-        return False
-    return force_text(blockNumber) in {"latest", "pending", "earliest"}
-
-
-def inputBlockNumberFormatter(blockNumber):
-    if not blockNumber:
-        return None
-    elif isPredefinedBlockNumber(blockNumber):
-        return blockNumber
-    return to_hex(blockNumber)
-
-
 @coerce_args_to_text
 @coerce_return_to_text
 def input_call_formatter(eth, txn):

--- a/web3/formatters.py
+++ b/web3/formatters.py
@@ -6,7 +6,6 @@ import operator
 from web3.iban import Iban
 
 from web3.utils.string import (
-    force_text,
     coerce_args_to_text,
     coerce_return_to_text,
 )
@@ -26,7 +25,6 @@ from web3.utils.formatting import (
     add_0x_prefix,
 )
 from web3.utils.encoding import (
-    to_hex,
     encode_hex,
     decode_hex,
     from_decimal,

--- a/web3/utils/blocks.py
+++ b/web3/utils/blocks.py
@@ -1,0 +1,8 @@
+from .types import is_string
+from .string import force_text
+
+
+def is_predefined_block_number(block_number):
+    if not is_string(block_number):
+        return False
+    return force_text(block_number) in {"latest", "pending", "earliest"}


### PR DESCRIPTION
### What was wrong?

`web3.eth.getBlock('latest')` doesn't work, and neither do the majority of the other methods that use these sort of identifiers.

### How was it fixed?

Change logic to use the right endpoint with one of the predefined identifiers is passed in.

#### Cute Animal Picture

![snape-as-a-harry-potter-cat-harry-potter-16828518-281-400](https://cloud.githubusercontent.com/assets/824194/18319800/8cb7dee6-74e4-11e6-8bfe-861a2b42238e.jpg)


