### PR TITLE
Allow to specify timeouts for RPC interaction.

### DIFF
--- a/web3/providers/rpc.py
+++ b/web3/providers/rpc.py
@@ -8,10 +8,19 @@ from .base import BaseProvider  # noqa: E402
 
 
 class RPCProvider(BaseProvider):
-    def __init__(self, host="127.0.0.1", port="8545", path="/", *args, **kwargs):
+
+    def __init__(self, host="127.0.0.1", port="8545", path="/", connection_timeout=10, network_timeout=10, *args, **kwargs):
+        """Create a new RPC client.
+
+        :param connection_timeout: See :class:`geventhttpclient.HTTPClient`
+
+        :param network_timeout: See :class:`geventhttpclient.HTTPClient`
+        """
         self.host = host
         self.port = int(port)
         self.path = path
+        self.connection_timeout = connection_timeout
+        self.network_timeout = network_timeout
 
         super(RPCProvider, self).__init__(*args, **kwargs)
 
@@ -25,6 +34,8 @@ class RPCProvider(BaseProvider):
         client = HTTPClient(
             host=self.host,
             port=self.port,
+            connection_timeout=self.connection_timeout,
+            network_timeout=self.network_timeout,
             headers={
                 'Content-Type': 'application/json',
                 'User-Agent': request_user_agent,

--- a/web3/providers/rpc.py
+++ b/web3/providers/rpc.py
@@ -9,7 +9,14 @@ from .base import BaseProvider  # noqa: E402
 
 class RPCProvider(BaseProvider):
 
-    def __init__(self, host="127.0.0.1", port="8545", path="/", connection_timeout=10, network_timeout=10, *args, **kwargs):
+    def __init__(self, 
+                 host="127.0.0.1", 
+                 port="8545", 
+                 path="/", 
+                 connection_timeout=10, 
+                 network_timeout=10, 
+                 *args, 
+                 **kwargs):
         """Create a new RPC client.
 
         :param connection_timeout: See :class:`geventhttpclient.HTTPClient`


### PR DESCRIPTION
### What was wrong?

Default RPC network timeout was too low for busy CI environment.

### How was it fixed?

Allow to specify timeouts.

#### Cute Animal Picture

![Cute animal picture](http://www.cutestpaw.com/wp-content/uploads/2014/05/TURTLE.jpg)

