### PR TITLE
Small cleanups for contract API

### DIFF
--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -214,12 +214,7 @@ Events
     Creates a new :py:class:`web3.utils.filters.PastLogFilter` instance which
     will match historical event logs.
 
-    All parameters behave the same as the :py:method::`Contract.on` method with
-    the exception that:
-
-    * ``filter_params`` parameter may not contain the keys ``toBlock`` or
-      ``fromBlock``.
-
+    All parameters behave the same as the :py:method::`Contract.on` method.
 
     .. code-block:: python
 

--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -100,7 +100,7 @@ Each Contract Factory exposes the following methods.
         "0x4e3a3754410177e6937ef1f84bba68ea139e8d1a2258c5f85db9f1cd715a1bdd"
 
 
-.. py:method:: Contract.call(transaction).myMethod(*args)
+.. py:method:: Contract.call(transaction).myMethod(*args, **kwargs)
 
     Call a contract function, executing the transaction locally using the
     ``eth_call`` API.  This will not create a new public transaction.
@@ -121,7 +121,7 @@ Each Contract Factory exposes the following methods.
         54321  # the token balance for the account `web3.eth.accounts[1]`
 
 
-.. py:method:: Contract.estimateGas(transaction).myMethod(*args)
+.. py:method:: Contract.estimateGas(transaction).myMethod(*args, **kwargs)
 
     Call a contract function, executing the transaction locally using the
     ``eth_call`` API.  This will not create a new public transaction.

--- a/tests/contracts/test_contract_call_interface.py
+++ b/tests/contracts/test_contract_call_interface.py
@@ -19,7 +19,7 @@ def math_contract(web3_tester, MathContract):
 
 @pytest.fixture()
 def string_contract(web3_tester, StringContract):
-    deploy_txn = StringContract.deploy(arguments=["Caqalai"])
+    deploy_txn = StringContract.deploy(args=["Caqalai"])
     deploy_receipt = web3_tester.eth.getTransactionReceipt(deploy_txn)
     assert deploy_receipt is not None
     _string_contract = StringContract(address=deploy_receipt['contractAddress'])
@@ -28,7 +28,7 @@ def string_contract(web3_tester, StringContract):
 
 @pytest.fixture()
 def address_contract(web3_tester, WithConstructorAddressArgumentsContract):
-    deploy_txn = WithConstructorAddressArgumentsContract.deploy(arguments=[
+    deploy_txn = WithConstructorAddressArgumentsContract.deploy(args=[
         "0xd3cda913deb6f67967b99d67acdfa1712c293601",
     ])
     deploy_receipt = web3_tester.eth.getTransactionReceipt(deploy_txn)

--- a/tests/contracts/test_contract_constructor_encoding.py
+++ b/tests/contracts/test_contract_constructor_encoding.py
@@ -31,7 +31,7 @@ def test_contract_constructor_abi_encoding_with_constructor_with_no_args(SimpleC
     ),
 )
 def test_error_if_invalid_arguments_supplied(WithConstructorArgumentsContract, arguments):
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         WithConstructorArgumentsContract._encodeConstructorData(arguments)
 
 

--- a/tests/contracts/test_contract_constructor_encoding.py
+++ b/tests/contracts/test_contract_constructor_encoding.py
@@ -9,13 +9,13 @@ from web3.utils.formatting import remove_0x_prefix
 
 
 def test_contract_constructor_abi_encoding_with_no_constructor_fn(MathContract, MATH_CODE):
-    deploy_data = MathContract._encodeConstructorData()
+    deploy_data = MathContract._encode_constructor_data()
     assert deploy_data == MATH_CODE
 
 
 def test_contract_constructor_abi_encoding_with_constructor_with_no_args(SimpleConstructorContract,
                                                                          SIMPLE_CONSTRUCTOR_CODE):
-    deploy_data = SimpleConstructorContract._encodeConstructorData()
+    deploy_data = SimpleConstructorContract._encode_constructor_data()
     assert deploy_data == SIMPLE_CONSTRUCTOR_CODE
 
 
@@ -32,11 +32,11 @@ def test_contract_constructor_abi_encoding_with_constructor_with_no_args(SimpleC
 )
 def test_error_if_invalid_arguments_supplied(WithConstructorArgumentsContract, arguments):
     with pytest.raises(TypeError):
-        WithConstructorArgumentsContract._encodeConstructorData(arguments)
+        WithConstructorArgumentsContract._encode_constructor_data(arguments)
 
 
 def test_contract_constructor_encoding_encoding(WithConstructorArgumentsContract):
-    deploy_data = WithConstructorArgumentsContract._encodeConstructorData([1234, 'abcd'])
+    deploy_data = WithConstructorArgumentsContract._encode_constructor_data([1234, 'abcd'])
     encoded_args = '0x00000000000000000000000000000000000000000000000000000000000004d26162636400000000000000000000000000000000000000000000000000000000'
     expected_ending = encode_hex(encode_abi(['uint256', 'bytes32'], [1234, b'abcd']))
     assert expected_ending == encoded_args

--- a/tests/contracts/test_contract_constructor_encoding.py
+++ b/tests/contracts/test_contract_constructor_encoding.py
@@ -9,13 +9,13 @@ from web3.utils.formatting import remove_0x_prefix
 
 
 def test_contract_constructor_abi_encoding_with_no_constructor_fn(MathContract, MATH_CODE):
-    deploy_data = MathContract.encodeConstructorData()
+    deploy_data = MathContract._encodeConstructorData()
     assert deploy_data == MATH_CODE
 
 
 def test_contract_constructor_abi_encoding_with_constructor_with_no_args(SimpleConstructorContract,
                                                                          SIMPLE_CONSTRUCTOR_CODE):
-    deploy_data = SimpleConstructorContract.encodeConstructorData()
+    deploy_data = SimpleConstructorContract._encodeConstructorData()
     assert deploy_data == SIMPLE_CONSTRUCTOR_CODE
 
 
@@ -32,11 +32,11 @@ def test_contract_constructor_abi_encoding_with_constructor_with_no_args(SimpleC
 )
 def test_error_if_invalid_arguments_supplied(WithConstructorArgumentsContract, arguments):
     with pytest.raises(ValueError):
-        WithConstructorArgumentsContract.encodeConstructorData(arguments)
+        WithConstructorArgumentsContract._encodeConstructorData(arguments)
 
 
 def test_contract_constructor_encoding_encoding(WithConstructorArgumentsContract):
-    deploy_data = WithConstructorArgumentsContract.encodeConstructorData([1234, 'abcd'])
+    deploy_data = WithConstructorArgumentsContract._encodeConstructorData([1234, 'abcd'])
     encoded_args = '0x00000000000000000000000000000000000000000000000000000000000004d26162636400000000000000000000000000000000000000000000000000000000'
     expected_ending = encode_hex(encode_abi(['uint256', 'bytes32'], [1234, b'abcd']))
     assert expected_ending == encoded_args

--- a/tests/contracts/test_contract_deployment.py
+++ b/tests/contracts/test_contract_deployment.py
@@ -33,7 +33,7 @@ def test_contract_deployment_with_constructor_without_args(web3_tester,
 def test_contract_deployment_with_constructor_with_arguments(web3_tester,
                                                              WithConstructorArgumentsContract,
                                                              WITH_CONSTRUCTOR_ARGUMENTS_RUNTIME):
-    deploy_txn = WithConstructorArgumentsContract.deploy(arguments=[1234, 'abcd'])
+    deploy_txn = WithConstructorArgumentsContract.deploy(args=[1234, 'abcd'])
 
     txn_receipt = web3_tester.eth.getTransactionReceipt(deploy_txn)
     assert txn_receipt is not None
@@ -48,7 +48,7 @@ def test_contract_deployment_with_constructor_with_arguments(web3_tester,
 def test_contract_deployment_with_constructor_with_address_argument(web3_tester,
                                                                     WithConstructorAddressArgumentsContract,
                                                                     WITH_CONSTRUCTOR_ADDRESS_RUNTIME):
-    deploy_txn = WithConstructorAddressArgumentsContract.deploy(arguments=["0x16d9983245de15e7a9a73bc586e01ff6e08de737"])
+    deploy_txn = WithConstructorAddressArgumentsContract.deploy(args=["0x16d9983245de15e7a9a73bc586e01ff6e08de737"])
 
     txn_receipt = web3_tester.eth.getTransactionReceipt(deploy_txn)
     assert txn_receipt is not None

--- a/tests/contracts/test_contract_estimateGas.py
+++ b/tests/contracts/test_contract_estimateGas.py
@@ -31,7 +31,7 @@ def math_contract(web3, MATH_ABI, MATH_CODE, MATH_RUNTIME, MATH_SOURCE,
 
 
 def test_contract_estimateGas(web3, math_contract):
-    increment_abi = math_contract.find_matching_fn_abi('increment', [])
+    increment_abi = math_contract._find_matching_fn_abi('increment', [])
     call_data = function_abi_to_4byte_selector(increment_abi)
     gas_estimate = math_contract.estimateGas().increment()
 

--- a/tests/contracts/test_contract_method_to_argument_matching.py
+++ b/tests/contracts/test_contract_method_to_argument_matching.py
@@ -14,7 +14,7 @@ MULTIPLE_FUNCTIONS = json.loads('[{"constant":false,"inputs":[],"name":"a","outp
 def test_finds_single_function_without_args(web3_tester):
     Contract = web3_tester.eth.contract(SINGLE_FN_NO_ARGS)
 
-    abi = Contract.find_matching_fn_abi('a', [])
+    abi = Contract._find_matching_fn_abi('a', [])
     assert abi['name'] == 'a'
     assert abi['inputs'] == []
 
@@ -22,7 +22,7 @@ def test_finds_single_function_without_args(web3_tester):
 def test_finds_single_function_with_args(web3_tester):
     Contract = web3_tester.eth.contract(SINGLE_FN_ONE_ARG)
 
-    abi = Contract.find_matching_fn_abi('a', [1234])
+    abi = Contract._find_matching_fn_abi('a', [1234])
     assert abi['name'] == 'a'
     assert len(abi['inputs']) == 1
     assert abi['inputs'][0]['type'] == 'uint256'
@@ -32,7 +32,7 @@ def test_error_when_no_function_name_match(web3_tester):
     Contract = web3_tester.eth.contract(SINGLE_FN_NO_ARGS)
 
     with pytest.raises(ValueError):
-        Contract.find_matching_fn_abi('no_function_name', [1234])
+        Contract._find_matching_fn_abi('no_function_name', [1234])
 
 
 @pytest.mark.parametrize(
@@ -48,7 +48,7 @@ def test_error_when_no_function_name_match(web3_tester):
 def test_finds_function_with_matching_args(web3_tester, arguments, expected_types):
     Contract = web3_tester.eth.contract(MULTIPLE_FUNCTIONS)
 
-    abi = Contract.find_matching_fn_abi('a', arguments)
+    abi = Contract._find_matching_fn_abi('a', arguments)
     assert abi['name'] == 'a'
     assert len(abi['inputs']) == len(expected_types)
     assert set(get_abi_input_types(abi)) == set(expected_types)
@@ -58,4 +58,4 @@ def test_error_when_duplicate_match(web3_tester):
     Contract = web3_tester.eth.contract(MULTIPLE_FUNCTIONS)
 
     with pytest.raises(ValueError):
-        abi = Contract.find_matching_fn_abi('a', [100])
+        abi = Contract._find_matching_fn_abi('a', [100])

--- a/tests/contracts/test_contract_transact_interface.py
+++ b/tests/contracts/test_contract_transact_interface.py
@@ -22,7 +22,7 @@ def math_contract(web3_tester, MathContract):
 
 @pytest.fixture()
 def string_contract(web3_tester, StringContract):
-    deploy_txn = StringContract.deploy(arguments=["Caqalai"])
+    deploy_txn = StringContract.deploy(args=["Caqalai"])
     deploy_receipt = web3_tester.eth.getTransactionReceipt(deploy_txn)
     assert deploy_receipt is not None
     _math_contract = StringContract(address=deploy_receipt['contractAddress'])
@@ -98,7 +98,7 @@ def test_transacting_with_contract_respects_explicit_gas(web3,
 
     StringContract = web3.eth.contract(**STRING_CONTRACT)
 
-    deploy_txn = StringContract.deploy(arguments=["Caqalai"])
+    deploy_txn = StringContract.deploy(args=["Caqalai"])
     deploy_receipt = wait_for_transaction_receipt(web3, deploy_txn, 30)
     assert deploy_receipt is not None
     string_contract = StringContract(address=deploy_receipt['contractAddress'])
@@ -126,7 +126,7 @@ def test_auto_gas_computation_when_transacting(web3,
 
     StringContract = web3.eth.contract(**STRING_CONTRACT)
 
-    deploy_txn = StringContract.deploy(arguments=["Caqalai"])
+    deploy_txn = StringContract.deploy(args=["Caqalai"])
     deploy_receipt = wait_for_transaction_receipt(web3, deploy_txn, 30)
     assert deploy_receipt is not None
     string_contract = StringContract(address=deploy_receipt['contractAddress'])

--- a/tests/contracts/test_extracting_event_data.py
+++ b/tests/contracts/test_extracting_event_data.py
@@ -61,7 +61,7 @@ def test_event_data_extraction(web3_tester_persistent,
     assert len(txn_receipt['logs']) == 1
     log_entry = txn_receipt['logs'][0]
 
-    event_abi = emitter.find_matching_event_abi(event_name)
+    event_abi = emitter._find_matching_event_abi(event_name)
 
     event_topic = getattr(emitter_log_topics, event_name)
     is_anonymous = event_abi['anonymous']

--- a/tests/eth-module/test_eth_estimateGas.py
+++ b/tests/eth-module/test_eth_estimateGas.py
@@ -31,7 +31,7 @@ def math_contract(web3, MATH_ABI, MATH_CODE, MATH_RUNTIME, MATH_SOURCE,
 
 
 def test_eth_estimateGas(web3, math_contract):
-    increment_abi = math_contract.find_matching_fn_abi('increment', [])
+    increment_abi = math_contract._find_matching_fn_abi('increment', [])
     call_data = function_abi_to_4byte_selector(increment_abi)
     gas_estimate = web3.eth.estimateGas({
         'to': math_contract.address,

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -32,7 +32,6 @@ from web3.utils.abi import (
     get_abi_input_types,
     get_abi_output_types,
     get_constructor_abi,
-    check_if_arguments_can_be_encoded,
     function_abi_to_4byte_selector,
     merge_args_and_kwargs,
     normalize_return_type,
@@ -52,14 +51,16 @@ from web3.utils.filters import (
 class Contract(object):
     """Base class for Contract proxy classes.
 
-    First you need to create your Contract classes using :func:`construct_contract_class`
-    that takes compiled Solidity contract ABI definitions as input.
-    The created class object will be a subclass of this base class.
+    First you need to create your Contract classes using
+    :func:`construct_contract_factory` that takes compiled Solidity contract
+    ABI definitions as input.  The created class object will be a subclass of
+    this base class.
 
-    After you have your Contract proxy class created you can interact with smart contracts
+    After you have your Contract proxy class created you can interact with
+    smart contracts
 
-    * Create a Contract proxy object for an existing deployed smart contract by its address
-      using :meth:`__init__`
+    * Create a Contract proxy object for an existing deployed smart contract by
+      its address using :meth:`__init__`
 
     * Deploy a new smart contract using :py:meth:`Contract.deploy`
     """
@@ -76,7 +77,12 @@ class Contract(object):
     # instance level properties
     address = None
 
-    def __init__(self, abi=None, address=None, code=None, code_runtime=None, source=None):
+    def __init__(self,
+                 abi=None,
+                 address=None,
+                 code=None,
+                 code_runtime=None,
+                 source=None):
         """Create a new smart contract proxy object.
 
         :param address: Contract address as 0x hex string
@@ -120,7 +126,9 @@ class Contract(object):
         if self._code_runtime is not None:
             return self._code_runtime
         # TODO: runtime can be derived from the contract source.
-        raise AttributeError("No contract code_runtime was specified for thes contract")
+        raise AttributeError(
+            "No contract code_runtime was specified for thes contract"
+        )
 
     @property
     def source(self):
@@ -129,7 +137,7 @@ class Contract(object):
         raise AttributeError("No contract source was specified for thes contract")
 
     @classmethod
-    def deploy(cls, transaction=None, arguments=None):
+    def deploy(cls, transaction=None, args=None, kwargs=None):
         """
         Deploys the contract on a blockchain.
 
@@ -137,89 +145,23 @@ class Contract(object):
 
         .. code-block:: python
 
-            from typing import Optional, Tuple
-
-            from gevent import Timeout
-            from web3 import Web3
-            from web3.contract import Contract, construct_contract_class
-
-            from populus.utils.transactions import (
-                get_contract_address_from_txn,
-                wait_for_transaction_receipt
+            >>> MyContract.deploy(
+                transaction={
+                    'from': web3.eth.accounts[1],
+                    'value': 12345,
+                },
+                args=('DGD', 18),
             )
+            '0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060'
 
+        :param transaction: Transaction parameters for the deployment
+                            transaction as a dict
 
-            def deploy_contract(
-                    web3: Web3,
-                    contract_definition: dict,
-                    gas=1500000,
-                    timeout=60.0,
-                    constructor_arguments: Optional[list]=None,
-                    from_account=None) -> Tuple[Contract, str]:
-                '''Deploys a single contract using Web3 client.
+        :param args: The contract constructor arguments as positional arguments
+        :param kwargs: The contract constructor arguments as keyword arguments
 
-                :param web3: Web3 client instance
-
-                :param contract_definition: Dictionary of describing the contract interface,
-                    as read from ``contracts.json`` Contains
-
-                :param gas: Max gas
-
-                :param timeout: How many seconds to wait the transaction to
-                    confirm to get the contract address.
-
-                :param constructor_arguments: Arguments passed to the smart contract
-                    constructor. Automatically encoded through ABI signature.
-
-                :param from_account: Geth account that's balance is used for deployment.
-                    By default, the gas is spent from Web3 coinbase account.
-                    Account must be unlocked.
-
-                :return: Tuple containing Contract proxy object and the
-                    transaction hash where it was deployed
-
-                :raise gevent.timeout.Timeout: If we can't get our contract
-                    in a block within given timeout
-                '''
-
-                # Check we are passed valid contract definition
-                assert "abi" in contract_definition, \
-                    "Please pass a valid contract definition dictionary, got {}".
-                        format(contract_definition)
-
-                contract_class = construct_contract_class(
-                    web3=web3,
-                    abi=contract_definition["abi"],
-                    code=contract_definition["code"],
-                    code_runtime=contract_definition["code_runtime"],
-                    source=contract_definition["source"],
-                        )
-
-                if not from_account:
-                    from_account = web3.eth.coinbase
-
-                # Set transaction parameters
-                transaction = {
-                    "gas": gas,
-                    "from": from_account,
-                }
-
-                # Call web3 to deploy the contract
-                txn_hash = contract_class.deploy(transaction, constructor_arguments)
-
-                # Wait until we get confirmation and address
-                address = get_contract_address_from_txn(web3, txn_hash, timeout=timeout)
-
-                # Create Contract proxy object
-                contract = contract_class(address=address)
-
-                return contract, txn_hash
-
-        :param transaction: Transaction parameters for the deployment transaction as a dict
-
-        :param arguments: The contract constructor arguments
-
-        :return: 0x string formatted transaction hash of the deployment transaction
+        :return: hexidecimal transaction hash of the deployment
+                 transaction
         """
         if transaction is None:
             deploy_transaction = {}
@@ -228,18 +170,21 @@ class Contract(object):
 
         if not cls.code:
             raise ValueError(
-                "Cannot deploy a contract that does not have 'code' associated with it"
+                "Cannot deploy a contract that does not have 'code' associated "
+                "with it"
             )
+
         if 'data' in deploy_transaction:
             raise ValueError(
                 "Cannot specify `data` for contract deployment"
             )
+
         if 'to' in deploy_transaction:
             raise ValueError(
                 "Cannot specify `to` for contract deployment"
             )
 
-        deploy_transaction['data'] = cls.encodeConstructorData(arguments)
+        deploy_transaction['data'] = cls._encodeConstructorData(args, kwargs)
 
         # TODO: handle asynchronous contract creation
         txn_hash = cls.web3.eth.sendTransaction(deploy_transaction)
@@ -308,18 +253,64 @@ class Contract(object):
             raise ValueError("Multiple functions found")
 
     @classmethod
+    def get_function_info(cls, fn_name, args=None, kwargs=None):
+        fn_abi = cls.find_matching_fn_abi(fn_name, args, kwargs)
+        fn_selector = function_abi_to_4byte_selector(fn_abi)
+
+        fn_arguments = merge_args_and_kwargs(fn_abi, args, kwargs)
+
+        return fn_abi, fn_selector, fn_arguments
+
+    @combomethod
+    def _prepare_transaction(cls,
+                             fn_name,
+                             fn_args=None,
+                             fn_kwargs=None,
+                             transaction=None):
+        """
+        Returns a dictionary of the transaction that could be used to call this
+        """
+        if transaction is None:
+            prepared_transaction = {}
+        else:
+            prepared_transaction = dict(**transaction)
+
+        if 'data' in prepared_transaction:
+            raise ValueError("Transaction parameter may not contain a 'data' key")
+
+        fn_abi, fn_selector, fn_arguments = cls.get_function_info(
+            fn_name, fn_args, fn_kwargs,
+        )
+
+        if cls.address:
+            prepared_transaction.setdefault('to', cls.address)
+
+        prepared_transaction['data'] = cls._encodeABI(
+            fn_abi,
+            fn_arguments,
+            data=fn_selector,
+        )
+        return prepared_transaction
+
+    @classmethod
     @coerce_return_to_text
-    def encodeABI(cls, fn_name, arguments, data=None):
+    def encodeABI(cls, fn_name, args=None, kwargs=None, data=None):
         """
-        encodes the arguments using the Ethereum ABI.
+        encodes the arguments using the Ethereum ABI for the contract function
+        that matches the given name and arguments..
         """
-        function_abi = cls.find_matching_fn_abi(fn_name, force_obj_to_bytes(arguments))
-        return cls._encodeABI(function_abi, arguments, data)
+        fn_abi, _, fn_arguments = cls.get_function_info(
+            fn_name, args, kwargs,
+        )
+        return cls._encodeABI(fn_abi, fn_arguments, data)
 
     @classmethod
     def _encodeABI(cls, abi, arguments, data=None):
         arguent_types = get_abi_input_types(abi)
-        encoded_arguments = encode_abi(arguent_types, force_obj_to_bytes(arguments))
+        encoded_arguments = encode_abi(
+            arguent_types,
+            force_obj_to_bytes(arguments),
+        )
         if data:
             return add_0x_prefix(
                 force_bytes(remove_0x_prefix(data)) +
@@ -330,35 +321,33 @@ class Contract(object):
 
     @classmethod
     @coerce_return_to_text
-    def encodeConstructorData(cls, arguments=None):
-        if arguments is None:
-            arguments = []
+    def _encodeConstructorData(cls, args=None, kwargs=None):
+        constructor_abi = get_constructor_abi(cls.abi)
 
-        constructor = get_constructor_abi(cls.abi)
-        if constructor:
-            if constructor['inputs'] and not arguments:
+        if constructor_abi:
+            if args is None:
+                args = tuple()
+            if kwargs is None:
+                kwargs = {}
+
+            arguments = merge_args_and_kwargs(constructor_abi, args, kwargs)
+
+            if constructor_abi['inputs'] and not arguments:
                 raise ValueError(
                     "This contract requires {0} constructor arguments".format(
-                        len(constructor['inputs']),
+                        len(constructor_abi['inputs']),
                     )
                 )
-            if arguments:
-                if len(arguments) != len(constructor['inputs']):
-                    raise ValueError(
-                        "This contract requires {0} constructor arguments".format(
-                            len(constructor['inputs']),
-                        )
+            if arguments and len(arguments) != len(constructor_abi['inputs']):
+                raise ValueError(
+                    "This contract requires {0} constructor arguments".format(
+                        len(constructor_abi['inputs']),
                     )
-
-                is_encodable = check_if_arguments_can_be_encoded(
-                    constructor,
-                    arguments,
-                    {},
                 )
-                if not is_encodable:
-                    raise ValueError("Unable to encode provided arguments.")
 
-            deploy_data = add_0x_prefix(cls._encodeABI(constructor, arguments, data=cls.code))
+            deploy_data = add_0x_prefix(
+                cls._encodeABI(constructor_abi, arguments, data=cls.code)
+            )
         else:
             deploy_data = add_0x_prefix(cls.code)
 
@@ -404,15 +393,10 @@ class Contract(object):
         if filter_params is None:
             filter_params = {}
 
-        if 'fromBlock' in filter_params or 'toBlock' in filter_params:
-            raise ValueError("Cannot provide `fromBlock` or `toBlock` in `pastEvents` calls")
-
         event_filter_params = {}
         event_filter_params.update(filter_params)
-        event_filter_params.update({
-            'fromBlock': "earliest",
-            'toBlock': self.web3.eth.blockNumber,
-        })
+        event_filter_params.setdefault('fromBlock', 'earliest')
+        event_filter_params.setdefault('toBlock', self.web3.eth.blockNumber)
 
         log_filter = self.on(
             event_name,
@@ -431,6 +415,7 @@ class Contract(object):
 
         return past_log_filter
 
+    @combomethod
     def estimateGas(self, transaction=None):
         """
         Estimate the gas for a call
@@ -445,8 +430,20 @@ class Contract(object):
         if 'to' in estimate_transaction:
             raise ValueError("Cannot set to in call transaction")
 
-        estimate_transaction['to'] = self.address
+        if self.address:
+            estimate_transaction.setdefault('to', self.address)
         estimate_transaction.setdefault('from', self.web3.eth.coinbase)
+
+        if 'to' not in estimate_transaction:
+            if isinstance(self, type):
+                raise ValueError(
+                    "When using `Contract.estimateGas` from a contract factory "
+                    "you must provide a `to` address with the transaction"
+                )
+            else:
+                raise ValueError(
+                    "Please ensure that this contract instance has an address."
+                )
 
         contract = self
 
@@ -462,6 +459,7 @@ class Contract(object):
 
         return Caller()
 
+    @combomethod
     def call(self, transaction=None):
         """
         Execute a contract function call using the `eth_call` interface.
@@ -473,18 +471,16 @@ class Contract(object):
 
         .. code-block:: python
 
-            contract_class = construct_contract_class(
+            ContractFactory = construct_contract_factory(
                 web3=web3,
                 abi=wallet_contract_definition["abi"]
+            )
 
             # Not a real contract address
             contract = contract_class("0x2f70d3d26829e412a602e83fe8eebf80255aeea5")
 
             # Read "owner" public variable
-            bin_addr = contract.call().owner()
-
-            # Convert address to 0x format
-            address = "0x" + bin_addr.decode("ascii")
+            addr = contract.call().owner()
 
         :param transaction: Dictionary of transaction info for web3 interface
         :return: ``Caller`` object that has contract public functions
@@ -497,11 +493,21 @@ class Contract(object):
 
         if 'data' in call_transaction:
             raise ValueError("Cannot set data in call transaction")
-        if 'to' in call_transaction:
-            raise ValueError("Cannot set to in call transaction")
 
-        call_transaction['to'] = self.address
+        if self.address:
+            call_transaction.setdefault('to', self.address)
         call_transaction.setdefault('from', self.web3.eth.coinbase)
+
+        if 'to' not in call_transaction:
+            if isinstance(self, type):
+                raise ValueError(
+                    "When using `Contract.call` from a contract factory you "
+                    "must provide a `to` address with the transaction"
+                )
+            else:
+                raise ValueError(
+                    "Please ensure that this contract instance has an address."
+                )
 
         contract = self
 
@@ -517,56 +523,41 @@ class Contract(object):
 
         return Caller()
 
+    @combomethod
     def transact(self, transaction=None):
         """
-        Execute a contract function call using the `eth_sendTransaction` interface.
+        Execute a contract function call using the `eth_sendTransaction`
+        interface.
 
-        You should specify the account that pays the gas for this
-        transaction in `transaction`. If no account is specified the coinbase
-        account of web3 interface is used.
+        You should specify the account that pays the gas for this transaction
+        in `transaction`. If no account is specified the coinbase account of
+        web3 interface is used.
 
         Example:
 
         .. code-block:: python
 
-            # Assumes self.contract points to a Contract instance having withdraw() function
+            # Assume we have a Wallet contract with the following methods.
+            # * Wallet.deposit()  # deposits to `msg.sender`
+            # * Wallet.deposit(address to)  # deposits to the account indicated
+            #   by the `to` parameter.
+            # * Wallet.withdraw(address amount)
 
-            def withdraw(self,
-                    to_address: str,
-                    amount_in_eth: Decimal,
-                    from_account=None, max_gas=50000) -> str:
-                '''Withdraw funds from a hosted wallet contract.
+            >>> wallet = Wallet(address='0xdc3a9db694bcdd55ebae4a89b22ac6d12b3f0c24')
+            # Deposit to the `web3.eth.coinbase` account.
+            >>> wallet.transact({'value': 12345}).deposit()
+            '0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060'
+            # Deposit to some other account using funds from `web3.eth.coinbase`.
+            >>> wallet.transact({'value': 54321}).deposit(web3.eth.accounts[1])
+            '0xe122ba26d25a93911e241232d3ba7c76f5a6bfe9f8038b66b198977115fb1ddf'
+            # Withdraw 12345 wei.
+            >>> wallet.transact().withdraw(12345)
 
-                :param amount_in_eth: How much as ETH
-                :param to_address: Destination address we are withdrawing to
-                :param from_account: Which Geth account pays the gas
-                :return: Transaction hash as 0x string
-                '''
-
-                assert isinstance(amount_in_eth, Decimal)  # Don't let floats slip through
-
-                wei = to_wei(amount_in_eth)
-
-                if not from_account:
-                    # Default to coinbase for transaction fees
-                    from_account = self.contract.web3.eth.coinbase
-
-                tx_info = {
-                    # The Ethereum account that pays the gas for this operation
-                    "from": from_account,
-                    "gas": max_gas,
-                }
-
-                # Interact with underlying wrapped contract
-                txid = self.contract.transact(tx_info).withdraw(to_address, wei)
-                return txid
-
-        The transaction is created in the Ethereum node memory pool.
-        Transaction receipt is not available until the transaction has been mined.
-        See :func:`populus.transaction.wait_for_transaction_receipt`.
+        The new public transaction will be created.  Transaction receipt will
+        be available once the transaction has been mined.
 
         :param transaction: Dictionary of transaction info for web3 interface.
-            Variables include ``from``, ``gas``.
+        Variables include ``from``, ``gas``, ``value``, ``gasPrice``.
 
         :return: ``Transactor`` object that has contract
             public functions exposed as Python methods.
@@ -580,11 +571,21 @@ class Contract(object):
 
         if 'data' in transact_transaction:
             raise ValueError("Cannot set data in call transaction")
-        if 'to' in transact_transaction:
-            raise ValueError("Cannot set to in call transaction")
 
-        transact_transaction['to'] = self.address
+        if self.address is not None:
+            transact_transaction.setdefault('to', self.address)
         transact_transaction.setdefault('from', self.web3.eth.coinbase)
+
+        if 'to' not in transact_transaction:
+            if isinstance(self, type):
+                raise ValueError(
+                    "When using `Contract.transact` from a contract factory you "
+                    "must provide a `to` address with the transaction"
+                )
+            else:
+                raise ValueError(
+                    "Please ensure that this contract instance has an address."
+                )
 
         contract = self
 
@@ -607,37 +608,20 @@ def call_contract_function(contract,
                            transaction,
                            *args,
                            **kwargs):
-    """Calls a contract constant or function.
-
-    The function must not have state changing effects.
-    For those see :func:`transact_with_contract_function`
-
-    For usual cases, you do not want to call this directly,
-    but interact with your contract through :meth:`Contract.call` method.
-
-    :param contract: :class:`web3.contract.Contract` object instance
-    :param function_name: Contract function name to call
-    :param transaction: Transaction parameters to pass to underlying ``web3.eth.call``
-    :param *arguments: Arguments to be passed to contract function. Automatically encoded
-    :return: Function call results, encoded to Python object
     """
-    if transaction is None:
-        call_transaction = {}
-    else:
-        call_transaction = dict(**transaction)
-
-    function_abi = contract.find_matching_fn_abi(function_name, args, kwargs)
-    function_selector = function_abi_to_4byte_selector(function_abi)
-
-    arguments = merge_args_and_kwargs(function_abi, args, kwargs)
-
-    call_transaction['data'] = contract.encodeABI(
-        function_name,
-        arguments,
-        data=function_selector,
+    Helper function for interacting with a contract function using the
+    `eth_call` API.
+    """
+    call_transaction = contract._prepare_transaction(
+        fn_name=function_name,
+        fn_args=args,
+        fn_kwargs=kwargs,
+        transaction=transaction,
     )
 
     return_data = contract.web3.eth.call(call_transaction)
+
+    function_abi = contract.find_matching_fn_abi(function_name, args, kwargs)
 
     output_types = get_abi_output_types(function_abi)
     output_data = decode_abi(output_types, return_data)
@@ -659,77 +643,15 @@ def transact_with_contract_function(contract=None,
                                     transaction=None,
                                     *args,
                                     **kwargs):
-    """Transacts with a contract.
-
-    Sends in a transaction that interacts with the contract.
-    You should specify the account that pays the gas for this
-    transaction in `transaction`.
-
-    Example:
-
-    .. code-block:: python
-
-        def withdraw(self,
-                     to_address: str,
-                     amount_in_eth: Decimal,
-                     from_account=None,
-                     max_gas=50000) -> str:
-            '''Withdraw funds from a wallet contract.
-
-            :param amount_in_eth: How much as ETH
-            :param to_address: Destination address we are withdrawing to
-            :param from_account: Which Geth accout pays the gas
-            :return: Transaction hash
-            '''
-
-            assert isinstance(amount_in_eth, Decimal)  # Don't let floats slip through
-
-            wei = to_wei(amount_in_eth)
-
-            if not from_account:
-                # Default to coinbase for transaction fees
-                from_account = self.contract.web3.eth.coinbase
-
-            tx_info = {
-                # The Ethereum account that pays the gas for this operation
-                "from": from_account,
-                "gas": max_gas,
-            }
-
-            # Interact with underlying wrapped contract
-            txid = transact_with_contract_function(
-                self.contract, "withdraw", tx_info, to_address, wei,
-            )
-            return txid
-
-    The transaction is created in the Ethereum node memory pool.
-    Transaction receipt is not available until the transaction has been mined.
-    See :func:`populus.utils.transactions.wait_for_transaction`.
-
-    Usually there is no reason to call directly. Instead
-    use :meth:`Contract.transact` interface.
-
-    :param contract: :class:`web3.contract.Contract` object instance
-    :param function_name: Contract function name to call
-    :param transaction: Dictionary of transaction parameters to pass to
-                        underlying ``web3.eth.sendTransaction``
-    :param *arguments: Arguments to be passed to contract function. Automatically encoded
-    :return: String, 0x formatted transaction hash.
     """
-    if transaction is None:
-        transact_transaction = {}
-    else:
-        transact_transaction = dict(**transaction)
-
-    function_abi = contract.find_matching_fn_abi(function_name, args, kwargs)
-    function_selector = function_abi_to_4byte_selector(function_abi)
-
-    arguments = merge_args_and_kwargs(function_abi, args, kwargs)
-
-    transact_transaction['data'] = contract.encodeABI(
-        function_name,
-        arguments,
-        data=function_selector,
+    Helper function for interacting with a contract function by sending a
+    transaction.
+    """
+    transact_transaction = contract._prepare_transaction(
+        fn_name=function_name,
+        fn_args=args,
+        fn_kwargs=kwargs,
+        transaction=transaction,
     )
 
     txn_hash = contract.web3.eth.sendTransaction(transact_transaction)
@@ -746,28 +668,23 @@ def estimate_gas_for_function(contract=None,
     Don't call this directly, instead use :meth:`Contract.estimateGas`
     on your contract instance.
     """
-    if transaction is None:
-        estimate_transaction = {}
-    else:
-        estimate_transaction = dict(**transaction)
-
-    function_abi = contract.find_matching_fn_abi(function_name, args, kwargs)
-    function_selector = function_abi_to_4byte_selector(function_abi)
-
-    arguments = merge_args_and_kwargs(function_abi, args, kwargs)
-
-    estimate_transaction['data'] = contract.encodeABI(
-        function_name,
-        arguments,
-        data=function_selector,
+    estimate_transaction = contract._prepare_transaction(
+        fn_name=function_name,
+        fn_args=args,
+        fn_kwargs=kwargs,
+        transaction=transaction,
     )
 
     gas_estimate = contract.web3.eth.estimateGas(estimate_transaction)
     return gas_estimate
 
 
-def construct_contract_class(web3, abi, code=None,
-                             code_runtime=None, source=None):
+def construct_contract_factory(web3,
+                               abi,
+                               code=None,
+                               code_runtime=None,
+                               source=None,
+                               contract_name='Contract'):
     """Creates a new Contract class.
 
     Contract lass is a Python proxy class to interact with smart contracts.
@@ -784,28 +701,31 @@ def construct_contract_class(web3, abi, code=None,
 
     .. code-block:: python
 
-        # Assume we have a contract called Token from token.sol, as
-        # previously build by Populus command line client
-        contract_abis = json.load(open("build/contracts.json", "rt"))
-        contract_definition = contract_abis["Token"]
+        # Assume we have a Token contract
+        token_contract_data = {
+            'abi': [...],
+            'code': '0x...',
+            'code_runtime': '0x...',
+            'source': 'contract Token {.....}',
+        }
 
-        # contract_class is now Python "Token" class
-        contract_class = construct_contract_class(
+        # contract_factory is a python class that can be used to interact with
+        # or deploy the "Token" contract.
+        token_contract_factory = construct_contract_factory(
             web3=web3,
-            abi=contract_definition["abi"],
-            code=contract_definition["code"],
-            code_runtime=contract_definition["code_runtime"],
-            source=contract_definition["source"],
+            abi=token_contract_data["abi"],
+            code=token_contract_data["code"],
+            code_runtime=token_contract_data["code_runtime"],
+            source=token_contract_data["source"],
                 )
 
-        # Create Contract proxy object based on a given
-        # smart contract address in block chain
-        contract = contract_class(
+        # Create Contract instance to interact with a deployed smart contract.
+        token_contract = token_contract_factory(
             address=address,
-            abi=contract_definition["abi"],
-            code=contract_definition["code"],
-            code_runtime=contract_definition["code_runtime"],
-            source=contract_definition["source"])
+            abi=token_contract_data["abi"],
+            code=token_contract_data["code"],
+            code_runtime=token_contract_data["code_runtime"],
+            source=token_contract_data["source"])
 
 
     :param web3: Web3 connection
@@ -822,4 +742,4 @@ def construct_contract_class(web3, abi, code=None,
         'code_runtime': code_runtime,
         'source': source,
     }
-    return type('Contract', (Contract,), _dict)
+    return type(contract_name, (Contract,), _dict)

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -553,17 +553,13 @@ class Contract(object):
         if 'data' in prepared_transaction:
             raise ValueError("Transaction parameter may not contain a 'data' key")
 
-        fn_abi, fn_selector, fn_arguments = cls._get_function_info(
-            fn_name, fn_args, fn_kwargs,
-        )
-
         if cls.address:
             prepared_transaction.setdefault('to', cls.address)
 
-        prepared_transaction['data'] = cls._encode_abi(
-            fn_abi,
-            fn_arguments,
-            data=fn_selector,
+        prepared_transaction['data'] = cls._encode_transaction_data(
+            fn_name,
+            fn_args,
+            fn_kwargs,
         )
         return prepared_transaction
 
@@ -597,6 +593,14 @@ class Contract(object):
             )
         else:
             return encode_hex(encoded_arguments)
+
+    @classmethod
+    @coerce_return_to_text
+    def _encode_transaction_data(cls, fn_name, args=None, kwargs=None):
+        fn_abi, fn_selector, fn_arguments = cls._get_function_info(
+            fn_name, args, kwargs,
+        )
+        return add_0x_prefix(cls._encode_abi(fn_abi, fn_arguments, fn_selector))
 
     @classmethod
     @coerce_return_to_text

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -620,7 +620,6 @@ class Contract(object):
         return deploy_data
 
 
-
 @coerce_return_to_text
 def call_contract_function(contract,
                            function_name,

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -23,7 +23,7 @@ from web3.utils.filters import (
 from web3.utils.blocks import (
     is_predefined_block_number,
 )
-from web3.contract import construct_contract_class
+from web3.contract import construct_contract_factory
 
 
 class Eth(object):
@@ -279,7 +279,7 @@ class Eth(object):
         return self.request_manager.request_blocking("eth_uninstallFilter", [filter_id])
 
     def contract(self, abi, address=None, **kwargs):
-        contract_class = construct_contract_class(self.web3, abi, **kwargs)
+        contract_class = construct_contract_factory(self.web3, abi, **kwargs)
 
         if address is None:
             return contract_class


### PR DESCRIPTION
### What was wrong and how was it fixed?

* Removed some doc-string documentation from functions that are *private* and should not be documented in such granularity for fear someone will use them in their code.
* `Contract.deploy()` parameter `arguments` renamed to `args`
* `Contract.deploy()` now takes `args` and `kwargs` parameters to allow constructing with keyword arguments or positional arguments.
* `Contract.pastEvents` now allows you to specify a `fromBlock` or `toBlock`.  Previously these were forced to be `'earliest'` and `web3.eth.blockNumber` respectively.
* `Contract.call`, `Contract.transact` and `Contract.estimateGas` are now callable as class methods as well as instance methods.  When called this way, an `address` must be provided with the `transaction` parameter.
* `Contract.call`, `Contract.transact` and `Contract.estimateGas` now allow specifying an alternate `address` for the transaction.
* New useful private api `Contract._get_function_info(fn_name, args, kwargs)` which returns a 3-tuple (`fn_abi`, `fn_selector`, `fn_arguments`) which are respectively the function ABI definition, the functino 4-byte selector, and the combined function arguments.
* New useful private api `Contract._prepare_transaction(fn_name, args, kwargs, transaction)` which returns a fully prepared transaction dictionary.
* Rename all internal contract methods that are *private* to be prefixed with an underscore `_`.

#### Cute Animal Picture

![54f1c1ab4a824f9cd96fa3632a927eeae8e876128485d40f27c5291a0a683379_large](https://cloud.githubusercontent.com/assets/824194/18399557/c6cbcf38-768e-11e6-80c2-67d0fba2a6ad.jpg)
