### PR TITLE
Fix `Filter.get()` to work if no log entries are returned

### DIFF
--- a/web3/utils/filters.py
+++ b/web3/utils/filters.py
@@ -162,6 +162,9 @@ class LogFilter(BaseFilter):
         else:
             log_entries = self.web3.eth.getFilterLogs(self.filter_id)
 
+        if not log_entries:
+            log_entries = []
+
         formatted_log_entries = [
             self.format_entry(log_entry) for log_entry in log_entries
         ]


### PR DESCRIPTION
### What was wrong?
`eth_getFilterLogs` and `eth_getFilterChanges` return None, rather than an empty list, if no results are returned. This causes an exception in the following code that tries to iterate over it.

### How was it fixed?
Check if the result is falsy, and replace it with an empty list if so.
