### PR TITLE
Piper/fixes for abi signature generation

### DIFF
--- a/tests/eth-module/test_iban.py
+++ b/tests/eth-module/test_iban.py
@@ -132,7 +132,7 @@ def test_isValid(value, expected, web3_tester):
     (
         (
             'XE7338O073KYGTWWZN0F2WZ0R8PX5ZPPZS',
-            '00c5496aee77c1ba1f0854206a26dda82a81d6d8',
+            '0x00c5496aee77c1ba1f0854206a26dda82a81d6d8',
         ),
     )
 )

--- a/tests/utilities/test_is_probably_enum.py
+++ b/tests/utilities/test_is_probably_enum.py
@@ -1,0 +1,21 @@
+import pytest
+
+from web3.utils.abi import is_probably_enum
+
+
+@pytest.mark.parametrize(
+    'abi_type,should_match',
+    (
+        ('SomeEnum.SomeValue', True),
+        ('Some_Enum.Some_Value', True),
+        ('SomeEnum.someValue', True),
+        ('SomeEnum.some_value', True),
+        ('__SomeEnum__.some_value', True),
+        ('__SomeEnum__.__some_value__', True),
+        ('SomeEnum.__some_value__', True),
+        ('uint256', False),
+    ),
+)
+def test_is_probably_enum(abi_type, should_match):
+    is_match = is_probably_enum(abi_type)
+    assert is_match is should_match

--- a/tests/utilities/test_is_recognized_type.py
+++ b/tests/utilities/test_is_recognized_type.py
@@ -1,0 +1,47 @@
+import pytest
+
+from web3.utils.abi import is_recognized_type
+
+
+@pytest.mark.parametrize(
+    'abi_type,should_match',
+    (
+        ('uint', False),
+        ('uint256', True),
+        ('uint8', True),
+        ('uint7', False),
+        ('int', False),
+        ('int256', True),
+        ('int8', True),
+        ('int7', False),
+        ('byte', False),
+        ('bytes1', True),
+        ('bytes7', True),
+        ('bytes32', True),
+        ('bytes', True),
+        ('string', True),
+        ('address', True),
+        ('uint256[]', True),
+        ('uint256[][]', True),
+        ('uint256[][][]', True),
+        ('uint256[1][][3]', True),
+        ('uint256[1][20000][3]', True),
+        ('uint256[][20000][]', True),
+        ('bytes20[]', True),
+        ('bytes20[][]', True),
+        ('bytes20[][][]', True),
+        ('bytes20[1][][3]', True),
+        ('bytes20[1][20000][3]', True),
+        ('bytes20[][20000][]', True),
+        ('address[]', True),
+        ('address[][]', True),
+        ('address[][][]', True),
+        ('address[1][][3]', True),
+        ('address[1][20000][3]', True),
+        ('address[][20000][]', True),
+        ('SomeEnum.SomeValue', False),
+    ),
+)
+def test_is_recognized_type(abi_type, should_match):
+    is_match = is_recognized_type(abi_type)
+    assert is_match is should_match

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -707,7 +707,8 @@ def construct_contract_factory(web3,
                                code=None,
                                code_runtime=None,
                                source=None,
-                               contract_name='Contract'):
+                               contract_name='Contract',
+                               base_contract_factory_class=Contract):
     """Creates a new Contract class.
 
     Contract lass is a Python proxy class to interact with smart contracts.
@@ -765,4 +766,4 @@ def construct_contract_factory(web3,
         'code_runtime': code_runtime,
         'source': source,
     }
-    return type(contract_name, (Contract,), _dict)
+    return type(contract_name, (base_contract_factory_class,), _dict)

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -268,6 +268,7 @@ class Contract(object):
             log_entry_formatter=log_filter.log_entry_formatter,
             data_filter_set=log_filter.data_filter_set,
         )
+        past_log_filter.filter_params = log_filter.filter_params
 
         if callbacks:
             past_log_filter.watch(*callbacks)

--- a/web3/iban.py
+++ b/web3/iban.py
@@ -7,6 +7,7 @@ from web3.utils.types import (
 )
 from web3.utils.formatting import (
     pad_left,
+    add_0x_prefix,
 )
 
 
@@ -212,7 +213,7 @@ class Iban(object):
         if self.isDirect():
             base36 = self._iban[4:]
             asInt = int(base36, 36)
-            return pad_left_hex(baseN(asInt, 16), 20)
+            return add_0x_prefix(pad_left_hex(baseN(asInt, 16), 20))
 
         return ""
 

--- a/web3/main.py
+++ b/web3/main.py
@@ -10,6 +10,8 @@ from web3.shh import Shh
 from web3.txpool import TxPool
 from web3.version import Version
 
+from web3.iban import Iban
+
 from web3.providers.rpc import (
     RPCProvider,
     TestRPCProvider,
@@ -45,6 +47,9 @@ class Web3(object):
     RPCProvider = RPCProvider
     IPCProvider = IPCProvider
     TestRPCProvider = TestRPCProvider
+
+    # Iban
+    Iban = Iban
 
     # Encoding and Decoding
     toHex = staticmethod(to_hex)

--- a/web3/utils/abi.py
+++ b/web3/utils/abi.py
@@ -261,7 +261,7 @@ def is_probably_enum(abi_type):
     return bool(re.match(ENUM_REGEX, abi_type))
 
 
-def normalize_types_for_signature(abi_args):
+def normalize_event_input_types(abi_args):
     for arg in abi_args:
         if is_recognized_type(arg['type']):
             yield arg
@@ -275,7 +275,7 @@ def abi_to_signature(abi):
     function_signature = "{fn_name}({fn_input_types})".format(
         fn_name=abi['name'],
         fn_input_types=','.join([
-            arg['type'] for arg in normalize_types_for_signature(abi.get('inputs', []))
+            arg['type'] for arg in normalize_event_input_types(abi.get('inputs', []))
         ]),
     )
     return function_signature

--- a/web3/utils/events.py
+++ b/web3/utils/events.py
@@ -20,6 +20,7 @@ from .abi import (
     exclude_indexed_event_inputs,
     event_abi_to_log_topic,
     normalize_return_type,
+    normalize_event_input_types,
 )
 
 
@@ -131,7 +132,9 @@ def get_event_data(event_abi, log_entry):
         log_topics = log_entry['topics'][1:]
 
     log_topics_abi = get_indexed_event_inputs(event_abi)
-    log_topic_raw_types = get_abi_input_types({'inputs': log_topics_abi})
+    log_topic_raw_types = get_abi_input_types({
+        'inputs': normalize_event_input_types(log_topics_abi),
+    })
     log_topic_types = coerce_event_abi_types_for_decoding(log_topic_raw_types)
     log_topic_names = get_abi_input_names({'inputs': log_topics_abi})
 
@@ -143,7 +146,9 @@ def get_event_data(event_abi, log_entry):
 
     log_data = log_entry['data']
     log_data_abi = exclude_indexed_event_inputs(event_abi)
-    log_data_raw_types = get_abi_input_types({'inputs': log_data_abi})
+    log_data_raw_types = get_abi_input_types({
+        'inputs': normalize_event_input_types(log_data_abi),
+    })
     log_data_types = coerce_event_abi_types_for_decoding(log_data_raw_types)
     log_data_names = get_abi_input_names({'inputs': log_data_abi})
 

--- a/web3/utils/filters.py
+++ b/web3/utils/filters.py
@@ -162,7 +162,7 @@ class LogFilter(Filter):
         else:
             log_entries = self.web3.eth.getFilterLogs(self.filter_id)
 
-        if not log_entries:
+        if log_entries is None:
             log_entries = []
 
         formatted_log_entries = [


### PR DESCRIPTION
### What was wrong?

When an event signature included an enum the abi signature being generated was wrong.

### How was it fixed?

Fixed it to try to infer enum types.

#### Cute Animal Picture

![light-up-wizard-dog-costume-1](https://cloud.githubusercontent.com/assets/824194/18748238/e5e38b84-8103-11e6-9c03-9725624309ad.jpg)

