### PR TITLE
Correct use of geventhttpclient and RPC connection

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+Unreleased
+-----------
+
+* Introduced `KeepAliveRPCProvider` to correctly recycle HTTP connections and use HTTP keep alive
+
 2.9.0
 --------
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+2.9.0
+--------
+
+* Bugfix generation of event topics.
+* Web3.Iban now allows access to Iban address tools.
+
 2.8.1
 --------
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -27,10 +27,19 @@ The ``Web3`` object
 The common entrypoint for interacting with the Web3 library is the ``Web3``
 class.  You will need to instantiate a web3 instance.
 
+Web3 takes a connection to existing Ethereum node (*Geth* or *Parity*).
+This connection can be either over JSON-RPC using HTTP (TCP/IP)
+ or UNIX sockets (IPC).
+
 .. code-block:: python
 
-    >>> from web3 import Web, RPCProvider, IPCProvider
-    >>> web3 = Web3(RPCProvider(host='localhost', port='8545'))
+    >>> from web3 import Web, KeepAliveRPCProvider, IPCProvider
+
+    # Note that you should create only one RPCProvider per
+    # process, as it recycles underlying TCP/IP network connections between
+    # your process and Ethereum node
+    >>> web3 = Web3(KeepAliveRPCProvider(host='localhost', port='8545'))
+
     # or for an IPC based connection
     >>> web3 = Web3(IPCProvider())
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ readme = open(os.path.join(DIR, 'README.md')).read()
 
 setup(
     name='web3',
-    version='2.8.1',
+    version='2.9.0',
     description="""Web3.py""",
     long_description=readme,
     author='Piper Merriam',

--- a/tests/eth-module/test_iban.py
+++ b/tests/eth-module/test_iban.py
@@ -132,7 +132,7 @@ def test_isValid(value, expected, web3_tester):
     (
         (
             'XE7338O073KYGTWWZN0F2WZ0R8PX5ZPPZS',
-            '00c5496aee77c1ba1f0854206a26dda82a81d6d8',
+            '0x00c5496aee77c1ba1f0854206a26dda82a81d6d8',
         ),
     )
 )

--- a/tests/providers/conftest.py
+++ b/tests/providers/conftest.py
@@ -3,7 +3,7 @@ import pytest
 from gevent import socket
 
 from web3.providers.ipc import IPCProvider
-from web3.providers.rpc import TestRPCProvider, RPCProvider
+from web3.providers.rpc import TestRPCProvider, RPCProvider, KeepAliveRPCProvider
 
 
 def get_open_port():
@@ -15,7 +15,7 @@ def get_open_port():
     return port
 
 
-@pytest.fixture(params=['tester', 'rpc', 'ipc'])
+@pytest.fixture(params=['tester', 'rpc', 'ipc', 'keep-alive-rpc'])
 def disconnected_provider(request):
     """
     Supply a Provider that's not connected to a node.
@@ -31,6 +31,8 @@ def disconnected_provider(request):
         return provider
     elif request.param == 'rpc':
         return RPCProvider(port=9999)
+    elif request.param == 'rpc':
+        return KeepAliveRPCProvider(port=9999)
     elif request.param == 'ipc':
         return IPCProvider(ipc_path='nonexistent')
     else:

--- a/tests/providers/conftest.py
+++ b/tests/providers/conftest.py
@@ -31,8 +31,8 @@ def disconnected_provider(request):
         return provider
     elif request.param == 'rpc':
         return RPCProvider(port=9999)
-    elif request.param == 'rpc':
-        return KeepAliveRPCProvider(port=9999)
+    elif request.param == 'keep-alive-rpc':
+        return KeepAliveRPCProvider(port=9998)
     elif request.param == 'ipc':
         return IPCProvider(ipc_path='nonexistent')
     else:

--- a/tests/utilities/test_is_probably_enum.py
+++ b/tests/utilities/test_is_probably_enum.py
@@ -1,0 +1,21 @@
+import pytest
+
+from web3.utils.abi import is_probably_enum
+
+
+@pytest.mark.parametrize(
+    'abi_type,should_match',
+    (
+        ('SomeEnum.SomeValue', True),
+        ('Some_Enum.Some_Value', True),
+        ('SomeEnum.someValue', True),
+        ('SomeEnum.some_value', True),
+        ('__SomeEnum__.some_value', True),
+        ('__SomeEnum__.__some_value__', True),
+        ('SomeEnum.__some_value__', True),
+        ('uint256', False),
+    ),
+)
+def test_is_probably_enum(abi_type, should_match):
+    is_match = is_probably_enum(abi_type)
+    assert is_match is should_match

--- a/tests/utilities/test_is_recognized_type.py
+++ b/tests/utilities/test_is_recognized_type.py
@@ -1,0 +1,47 @@
+import pytest
+
+from web3.utils.abi import is_recognized_type
+
+
+@pytest.mark.parametrize(
+    'abi_type,should_match',
+    (
+        ('uint', False),
+        ('uint256', True),
+        ('uint8', True),
+        ('uint7', False),
+        ('int', False),
+        ('int256', True),
+        ('int8', True),
+        ('int7', False),
+        ('byte', False),
+        ('bytes1', True),
+        ('bytes7', True),
+        ('bytes32', True),
+        ('bytes', True),
+        ('string', True),
+        ('address', True),
+        ('uint256[]', True),
+        ('uint256[][]', True),
+        ('uint256[][][]', True),
+        ('uint256[1][][3]', True),
+        ('uint256[1][20000][3]', True),
+        ('uint256[][20000][]', True),
+        ('bytes20[]', True),
+        ('bytes20[][]', True),
+        ('bytes20[][][]', True),
+        ('bytes20[1][][3]', True),
+        ('bytes20[1][20000][3]', True),
+        ('bytes20[][20000][]', True),
+        ('address[]', True),
+        ('address[][]', True),
+        ('address[][][]', True),
+        ('address[1][][3]', True),
+        ('address[1][20000][3]', True),
+        ('address[][20000][]', True),
+        ('SomeEnum.SomeValue', False),
+    ),
+)
+def test_is_recognized_type(abi_type, should_match):
+    is_match = is_recognized_type(abi_type)
+    assert is_match is should_match

--- a/web3/__init__.py
+++ b/web3/__init__.py
@@ -18,5 +18,6 @@ __all__ = [
     "Web3",
     "RPCProvider",
     "TestRPCProvider",
+    "KeepAliveRPCProvider",
     "IPCProvider",
 ]

--- a/web3/__init__.py
+++ b/web3/__init__.py
@@ -6,6 +6,7 @@ import pkg_resources
 from web3.main import Web3
 from web3.providers.rpc import (
     RPCProvider,
+    KeepAliveRPCProvider,
     TestRPCProvider,
 )
 from web3.providers.ipc import IPCProvider

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -268,6 +268,7 @@ class Contract(object):
             log_entry_formatter=log_filter.log_entry_formatter,
             data_filter_set=log_filter.data_filter_set,
         )
+        past_log_filter.filter_params = log_filter.filter_params
 
         if callbacks:
             past_log_filter.watch(*callbacks)
@@ -706,7 +707,8 @@ def construct_contract_factory(web3,
                                code=None,
                                code_runtime=None,
                                source=None,
-                               contract_name='Contract'):
+                               contract_name='Contract',
+                               base_contract_factory_class=Contract):
     """Creates a new Contract class.
 
     Contract lass is a Python proxy class to interact with smart contracts.
@@ -764,4 +766,4 @@ def construct_contract_factory(web3,
         'code_runtime': code_runtime,
         'source': source,
     }
-    return type(contract_name, (Contract,), _dict)
+    return type(contract_name, (base_contract_factory_class,), _dict)

--- a/web3/iban.py
+++ b/web3/iban.py
@@ -7,6 +7,7 @@ from web3.utils.types import (
 )
 from web3.utils.formatting import (
     pad_left,
+    add_0x_prefix,
 )
 
 
@@ -212,7 +213,7 @@ class Iban(object):
         if self.isDirect():
             base36 = self._iban[4:]
             asInt = int(base36, 36)
-            return pad_left_hex(baseN(asInt, 16), 20)
+            return add_0x_prefix(pad_left_hex(baseN(asInt, 16), 20))
 
         return ""
 

--- a/web3/main.py
+++ b/web3/main.py
@@ -10,6 +10,8 @@ from web3.shh import Shh
 from web3.txpool import TxPool
 from web3.version import Version
 
+from web3.iban import Iban
+
 from web3.providers.rpc import (
     RPCProvider,
     TestRPCProvider,
@@ -45,6 +47,9 @@ class Web3(object):
     RPCProvider = RPCProvider
     IPCProvider = IPCProvider
     TestRPCProvider = TestRPCProvider
+
+    # Iban
+    Iban = Iban
 
     # Encoding and Decoding
     toHex = staticmethod(to_hex)

--- a/web3/providers/rpc.py
+++ b/web3/providers/rpc.py
@@ -7,6 +7,9 @@ import logging
 from .base import BaseProvider  # noqa: E402
 
 
+logger = logging.getLogger(__name__)
+
+
 class RPCProvider(BaseProvider):
     """Create a RPC client.
 
@@ -121,6 +124,7 @@ class KeepAliveRPCProvider(BaseProvider):
         client = KeepAliveRPCProvider.clients.get(key)
         if client:
             # Get in-process client instance for this host
+            logger.debug("Re-using HTTP client for RPC connection to %s", key)
             return client
 
         request_user_agent = 'Web3.py/{version}/{class_name}'.format(
@@ -141,6 +145,7 @@ class KeepAliveRPCProvider(BaseProvider):
             },
         )
 
+        logger.debug("Created new keep-alive HTTP client for RPC connection to %s", key)
         KeepAliveRPCProvider.clients[key] = client
         return client
 

--- a/web3/providers/rpc.py
+++ b/web3/providers/rpc.py
@@ -126,28 +126,28 @@ class KeepAliveRPCProvider(BaseProvider):
             # Get in-process client instance for this host
             logger.debug("Re-using HTTP client for RPC connection to %s", key)
             return client
+        else:
+            logger.debug("Created new keep-alive HTTP client for RPC connection to %s", key)
+            request_user_agent = 'Web3.py/{version}/{class_name}'.format(
+                version=web3_version,
+                class_name=type(self),
+            )
 
-        request_user_agent = 'Web3.py/{version}/{class_name}'.format(
-            version=web3_version,
-            class_name=type(self),
-        )
+            client = HTTPClient(
+                host=self.host,
+                port=self.port,
+                ssl=self.ssl,
+                connection_timeout=self.connection_timeout,
+                network_timeout=self.network_timeout,
+                concurrency=self.concurrency,
+                headers={
+                    'Content-Type': 'application/json',
+                    'User-Agent': request_user_agent,
+                },
+            )
 
-        client = HTTPClient(
-            host=self.host,
-            port=self.port,
-            ssl=self.ssl,
-            connection_timeout=self.connection_timeout,
-            network_timeout=self.network_timeout,
-            concurrency=self.concurrency,
-            headers={
-                'Content-Type': 'application/json',
-                'User-Agent': request_user_agent,
-            },
-        )
-
-        logger.debug("Created new keep-alive HTTP client for RPC connection to %s", key)
-        KeepAliveRPCProvider.clients[key] = client
-        return client
+            KeepAliveRPCProvider.clients[key] = client
+            return client
 
     def __str__(self):
         return "Keep-alive RPC connection {}:{}".format(self.host, self.port)

--- a/web3/providers/rpc.py
+++ b/web3/providers/rpc.py
@@ -32,6 +32,12 @@ class RPCProvider(BaseProvider):
 
         super(RPCProvider, self).__init__(*args, **kwargs)
 
+    def __str__(self):
+        return "RPC connection {}:{}".format(self.host, self.port)
+
+    def __repr__(self):
+        return self.__str__()
+
     def make_request(self, method, params):
         from web3 import __version__ as web3_version
         request_data = self.encode_rpc_request(method, params)
@@ -53,6 +59,91 @@ class RPCProvider(BaseProvider):
         with contextlib.closing(client):
             response = client.post(self.path, body=request_data)
             response_body = response.read()
+
+        return response_body
+
+
+class KeepAliveRPCProvider(BaseProvider):
+    """RPC-provider that handles HTTP keep-alive connection correctly.
+
+    HTTP client is recycled across requests. Create only one instance of KeepAliveProvider per process.
+    """
+
+    #: In-process client cache keyed by host:port -> HTTPClient
+    clients = {}
+
+    def __init__(self,
+                 host="127.0.0.1",
+                 port="8545",
+                 path="/",
+                 ssl=False,
+                 connection_timeout=10,
+                 network_timeout=10,
+                 concurrency=10,
+                 *args,
+                 **kwargs):
+        """Create a new RPC client.
+
+        :param concurrency: See :class:`geventhttpclient.HTTPClient`
+
+        :param connection_timeout: See :class:`geventhttpclient.HTTPClient`
+
+        :param network_timeout: See :class:`geventhttpclient.HTTPClient`
+        """
+        self.host = host
+        self.port = int(port)
+        self.path = path
+        self.ssl = ssl
+        self.connection_timeout = connection_timeout
+        self.network_timeout = network_timeout
+        self.concurrency = self.concurrency
+
+        super(KeepAliveRPCProvider, self).__init__(*args, **kwargs)
+
+        self.client = self.get_or_create_client()
+
+    def get_or_create_client(self):
+        from web3 import __version__ as web3_version
+
+        key = "{}:{}".format(self.host, self.port)
+        client = KeepAliveRPCProvider.clients.get(key)
+        if client:
+            # Get in-process client instance for this host
+            return client
+
+        request_user_agent = 'Web3.py/{version}/{class_name}'.format(
+            version=web3_version,
+            class_name=type(self),
+        )
+
+        client = HTTPClient(
+            host=self.host,
+            port=self.port,
+            ssl=self.ssl,
+            connection_timeout=self.connection_timeout,
+            network_timeout=self.network_timeout,
+            concurrency=self.concurrency,
+            headers={
+                'Content-Type': 'application/json',
+                'User-Agent': request_user_agent,
+            },
+        )
+
+        self.clients[key] = client
+        return client
+
+    def __str__(self):
+        return "Keep-alive RPC connection {}:{}".format(self.host, self.port)
+
+    def __repr__(self):
+        return self.__str__()
+
+    def make_request(self, method, params):
+
+        request_data = self.encode_rpc_request(method, params)
+
+        response = self.client.post(self.path, body=request_data)
+        response_body = response.read()
 
         return response_body
 
@@ -90,3 +181,4 @@ class TestRPCProvider(RPCProvider):
         self.thread = gevent.spawn(self.server.serve_forever)
 
         super(TestRPCProvider, self).__init__(host, str(port), *args, **kwargs)
+

--- a/web3/providers/rpc.py
+++ b/web3/providers/rpc.py
@@ -195,4 +195,3 @@ class TestRPCProvider(RPCProvider):
         self.thread = gevent.spawn(self.server.serve_forever)
 
         super(TestRPCProvider, self).__init__(host, str(port), *args, **kwargs)
-

--- a/web3/utils/abi.py
+++ b/web3/utils/abi.py
@@ -1,4 +1,5 @@
 import itertools
+import re
 
 from eth_abi.abi import (
     process_type,
@@ -205,11 +206,76 @@ def get_constructor_abi(contract_abi):
         raise ValueError("Found multiple constructors.")
 
 
-def abi_to_signature(function_abi):
+DYNAMIC_TYPES = ['bytes', 'string']
+
+STATIC_TYPES = list(itertools.chain(
+    ['address', 'bool'],
+    ['uint{0}'.format(i) for i in range(8, 257, 8)],
+    ['int{0}'.format(i) for i in range(8, 257, 8)],
+    ['bytes{0}'.format(i) for i in range(1, 33)],
+))
+
+BASE_TYPE_REGEX = '|'.join((
+    _type + '(?![a-z0-9])'
+    for _type
+    in itertools.chain(STATIC_TYPES, DYNAMIC_TYPES)
+))
+
+SUB_TYPE_REGEX = (
+    '\['
+    '[0-9]*'
+    '\]'
+)
+
+TYPE_REGEX = (
+    '^'
+    '(?:{base_type})'
+    '(?:(?:{sub_type})*)?'
+    '$'
+).format(
+    base_type=BASE_TYPE_REGEX,
+    sub_type=SUB_TYPE_REGEX,
+)
+
+
+def is_recognized_type(abi_type):
+    return bool(re.match(TYPE_REGEX, abi_type))
+
+
+NAME_REGEX = (
+    '[a-zA-Z_]'
+    '[a-zA-Z0-9_]*'
+)
+
+
+ENUM_REGEX = (
+    '^'
+    '{lib_name}'
+    '\.'
+    '{enum_name}'
+    '$'
+).format(lib_name=NAME_REGEX, enum_name=NAME_REGEX)
+
+
+def is_probably_enum(abi_type):
+    return bool(re.match(ENUM_REGEX, abi_type))
+
+
+def normalize_event_input_types(abi_args):
+    for arg in abi_args:
+        if is_recognized_type(arg['type']):
+            yield arg
+        elif is_probably_enum(arg['type']):
+            yield {k: 'uint8' if k == 'type' else v for k, v in arg.items()}
+        else:
+            yield arg
+
+
+def abi_to_signature(abi):
     function_signature = "{fn_name}({fn_input_types})".format(
-        fn_name=function_abi['name'],
+        fn_name=abi['name'],
         fn_input_types=','.join([
-            arg['type'] for arg in function_abi.get('inputs', [])
+            arg['type'] for arg in normalize_event_input_types(abi.get('inputs', []))
         ]),
     )
     return function_signature

--- a/web3/utils/events.py
+++ b/web3/utils/events.py
@@ -20,6 +20,7 @@ from .abi import (
     exclude_indexed_event_inputs,
     event_abi_to_log_topic,
     normalize_return_type,
+    normalize_event_input_types,
 )
 
 
@@ -131,7 +132,9 @@ def get_event_data(event_abi, log_entry):
         log_topics = log_entry['topics'][1:]
 
     log_topics_abi = get_indexed_event_inputs(event_abi)
-    log_topic_raw_types = get_abi_input_types({'inputs': log_topics_abi})
+    log_topic_raw_types = get_abi_input_types({
+        'inputs': normalize_event_input_types(log_topics_abi),
+    })
     log_topic_types = coerce_event_abi_types_for_decoding(log_topic_raw_types)
     log_topic_names = get_abi_input_names({'inputs': log_topics_abi})
 
@@ -143,7 +146,9 @@ def get_event_data(event_abi, log_entry):
 
     log_data = log_entry['data']
     log_data_abi = exclude_indexed_event_inputs(event_abi)
-    log_data_raw_types = get_abi_input_types({'inputs': log_data_abi})
+    log_data_raw_types = get_abi_input_types({
+        'inputs': normalize_event_input_types(log_data_abi),
+    })
     log_data_types = coerce_event_abi_types_for_decoding(log_data_raw_types)
     log_data_names = get_abi_input_names({'inputs': log_data_abi})
 

--- a/web3/utils/filters.py
+++ b/web3/utils/filters.py
@@ -162,7 +162,7 @@ class LogFilter(Filter):
         else:
             log_entries = self.web3.eth.getFilterLogs(self.filter_id)
 
-        if not log_entries:
+        if log_entries is None:
             log_entries = []
 
         formatted_log_entries = [


### PR DESCRIPTION
### What was wrong?

`RPCProvider` did not correctly use underlying geventhttpclient connection pool. This may easily cause the leakage of TCP/IP connections in long running processes.

Furthermore the old implementation did not correctly use HTTP Keep-Alive, leading to extra overhead when making RPC calls.

### How was it fixed?

Created a new class `KeepAliveRPCProvider` that maintains in-process per-host connection pool.  Old `RPCProvider` is still available for legacy API compatibility.

Documented the intended use of `KeepAliveRPCProvider´

#### Cute Animal Picture

![random](http://www.cutestpaw.com/wp-content/uploads/2016/02/This-is-Panda.jpg)
