### PR TITLE
Add poll_interval control to filter watcher

### DIFF
--- a/web3/utils/filters.py
+++ b/web3/utils/filters.py
@@ -60,6 +60,7 @@ class Filter(gevent.Greenlet):
     callbacks = None
     running = None
     stopped = False
+    poll_interval = None
 
     def __init__(self, web3, filter_id):
         self.web3 = web3
@@ -82,7 +83,10 @@ class Filter(gevent.Greenlet):
                     for callback_fn in self.callbacks:
                         if self.is_valid_entry(entry):
                             callback_fn(self.format_entry(entry))
-            gevent.sleep(random.random())
+            if self.poll_interval is None:
+                gevent.sleep(random.random())
+            else:
+                gevent.sleep(self.poll_interval)
 
     def format_entry(self, entry):
         """


### PR DESCRIPTION
### What was wrong?

The `Filter` class polls for new event logs using a `gevent.sleep(random.random())` between loops.  Once you get a few filters going this really starts hammering the RPC node.

### How was it fixed?

Added a `poll_interval` property that can be set on the class to change this polling frequency.

#### Cute Animal Picture

![dog_wizard33](https://cloud.githubusercontent.com/assets/824194/18973100/2c8de50c-8659-11e6-9b07-4d519573db6e.jpg)

