### PR TITLE
proper formatting for transactions

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,8 @@
 pytest>=2.8.2
 pytest-pythonpath>=0.3
 tox>=1.8.0
-eth-testrpc>=0.8.4
-ethereum-tester-client>=1.2.1
+eth-testrpc>=0.8.5
+ethereum-tester-client>=1.2.3
 py-geth>=1.2.0
 ethereum>=1.5.2
 secp256k1>=0.13.1

--- a/tests/utilities/test_formatter.py
+++ b/tests/utilities/test_formatter.py
@@ -70,12 +70,12 @@ def test_inputPostFormatter(value, expected):
         },
         {
             "data": '0x34234bf23bf4234',
-            "value": 100,
+            "value": hex(100),
             "from": '0x00c5496aee77c1ba1f0854206a26dda82a81d6d8',
             "to": '0x00c5496aee77c1ba1f0854206a26dda82a81d6d8',
-            "nonce": 1000,
-            "gas": 1000,
-            "gasPrice": 1000
+            "nonce": hex(1000),
+            "gas": hex(1000),
+            "gasPrice": hex(1000),
         }
     ),({
             "data": '0x34234bf23bf4234',
@@ -85,7 +85,7 @@ def test_inputPostFormatter(value, expected):
         },
         {
             "data": '0x34234bf23bf4234',
-            "value": 100,
+            "value": hex(100),
             "from": '0x00c5496aee77c1ba1f0854206a26dda82a81d6d8',
             "to": '0x00c5496aee77c1ba1f0854206a26dda82a81d6d8',
         }
@@ -99,11 +99,11 @@ def test_inputPostFormatter(value, expected):
         },
         {
             "data": '0x34234bf23bf4234',
-            "value": 100,
+            "value": hex(100),
             "from": '0x00c5496aee77c1ba1f0854206a26dda82a81d6d8',
             "to": '0x00c5496aee77c1ba1f0854206a26dda82a81d6d8',
-            "gas": 1000,
-            "gasPrice": 1000
+            "gas": hex(1000),
+            "gasPrice": hex(1000),
         },
     ), ({
             "data": '0x34234bf23bf4234',
@@ -115,11 +115,11 @@ def test_inputPostFormatter(value, expected):
         },
         {
             "data": '0x34234bf23bf4234',
-            "value": 100,
+            "value": hex(100),
             "from": '0x00c5496aee77c1ba1f0854206a26dda82a81d6d8',
             "to": '0x00c5496aee77c1ba1f0854206a26dda82a81d6d8',
-            "gas": 1000,
-            "gasPrice": 1000
+            "gas": hex(1000),
+            "gasPrice": hex(1000),
         },
     ), ({
             "data": '0x34234bf23bf4234',
@@ -130,10 +130,10 @@ def test_inputPostFormatter(value, expected):
         },
         {
             "data": '0x34234bf23bf4234',
-            "value": 100,
+            "value": hex(100),
             "from": '0x00c5496aee77c1ba1f0854206a26dda82a81d6d8',
-            "gas": 1000,
-            "gasPrice": 1000
+            "gas": hex(1000),
+            "gasPrice": hex(1000),
         }
     )]
 )

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -234,7 +234,7 @@ class Eth(object):
         return self.request_manager.request_blocking("eth_sign", [account, data_hash])
 
     def call(self, transaction, block_identifier=None):
-        formatted_transaction = formatters.input_call_formatter(self, transaction)
+        formatted_transaction = formatters.input_transaction_formatter(self, transaction)
         if block_identifier is None:
             block_identifier = self.defaultBlock
         return self.request_manager.request_blocking(
@@ -244,7 +244,11 @@ class Eth(object):
 
     @apply_formatters_to_return(to_decimal)
     def estimateGas(self, transaction):
-        return self.request_manager.request_blocking("eth_estimateGas", [transaction])
+        formatted_transaction = formatters.input_transaction_formatter(self, transaction)
+        return self.request_manager.request_blocking(
+            "eth_estimateGas",
+            [formatted_transaction],
+        )
 
     def filter(self, filter_params):
         if is_string(filter_params):

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -116,7 +116,10 @@ class Eth(object):
             block_identifier = self.defaultBlock
         return self.request_manager.request_blocking(
             "eth_getBalance",
-            [account, block_identifier],
+            [
+                account,
+                formatters.input_block_identifier_formatter(block_identifier),
+            ],
         )
 
     def getStorageAt(self, account, position, block_identifier=None):
@@ -124,7 +127,11 @@ class Eth(object):
             block_identifier = self.defaultBlock
         return self.request_manager.request_blocking(
             "eth_getStorageAt",
-            [account, self.web3.toHex(position), block_identifier],
+            [
+                account,
+                self.web3.toHex(position),
+                formatters.input_block_identifier_formatter(block_identifier),
+            ],
         )
 
     def getCode(self, account, block_identifier=None):
@@ -132,7 +139,10 @@ class Eth(object):
             block_identifier = self.defaultBlock
         return self.request_manager.request_blocking(
             "eth_getCode",
-            [account, block_identifier],
+            [
+                account,
+                formatters.input_block_identifier_formatter(block_identifier),
+            ],
         )
 
     @apply_formatters_to_return(formatters.output_block_formatter)
@@ -148,7 +158,10 @@ class Eth(object):
 
         return self.request_manager.request_blocking(
             method,
-            [block_identifier, full_transactions],
+            [
+                formatters.input_block_identifier_formatter(block_identifier),
+                full_transactions,
+            ],
         )
 
     @apply_formatters_to_return(to_decimal)
@@ -161,7 +174,10 @@ class Eth(object):
             method = 'eth_getBlockTransactionCountByNumber'
         else:
             method = 'eth_getBlockTransactionCountByHash'
-        return self.request_manager.request_blocking(method, [block_identifier])
+        return self.request_manager.request_blocking(
+            method,
+            [formatters.input_block_identifier_formatter(block_identifier)],
+        )
 
     def getUncle(self, block_identifier):
         """
@@ -189,7 +205,10 @@ class Eth(object):
             method = 'eth_getTransactionByBlockHashAndIndex'
         return self.request_manager.request_blocking(
             method,
-            [block_identifier, transaction_index],
+            [
+                formatters.input_block_identifier_formatter(block_identifier),
+                transaction_index,
+            ],
         )
 
     @apply_formatters_to_return(formatters.output_transaction_receipt_formatter)
@@ -205,7 +224,10 @@ class Eth(object):
             block_identifier = self.defaultBlock
         return self.request_manager.request_blocking(
             "eth_getTransactionCount",
-            [account, block_identifier],
+            [
+                account,
+                formatters.input_block_identifier_formatter(block_identifier),
+            ],
         )
 
     def sendTransaction(self, transaction):
@@ -220,7 +242,7 @@ class Eth(object):
 
         return self.request_manager.request_blocking(
             "eth_sendTransaction",
-            [formatted_transaction],
+            [formatters.input_transaction_formatter(self, formatted_transaction)],
         )
 
     def sendRawTransaction(self, raw_transaction):
@@ -239,7 +261,10 @@ class Eth(object):
             block_identifier = self.defaultBlock
         return self.request_manager.request_blocking(
             "eth_call",
-            [formatted_transaction, block_identifier],
+            [
+                formatted_transaction,
+                formatters.input_block_identifier_formatter(block_identifier),
+            ],
         )
 
     @apply_formatters_to_return(to_decimal)
@@ -266,7 +291,11 @@ class Eth(object):
                     "`latest` for string based filters"
                 )
         elif isinstance(filter_params, dict):
-            filter_id = self.request_manager.request_blocking("eth_newFilter", [filter_params])
+            formatted_filter_params = formatters.input_filter_params_formatter(filter_params)
+            filter_id = self.request_manager.request_blocking(
+                "eth_newFilter",
+                [formatted_filter_params],
+            )
             return LogFilter(self.web3, filter_id)
         else:
             raise ValueError("Must provide either a string or a valid filter object")

--- a/web3/formatters.py
+++ b/web3/formatters.py
@@ -66,22 +66,6 @@ def apply_to_array(formatter_fn):
 
 @coerce_args_to_text
 @coerce_return_to_text
-def input_call_formatter(eth, txn):
-    defaults = {
-        'from': eth.defaultAccount,
-    }
-    formatters = {
-        'from': input_address_formatter,
-        'to': input_address_formatter,
-    }
-    return {
-        key: formatters.get(key, identity)(txn.get(key, defaults.get(key)))
-        for key in set(tuple(txn.keys()) + tuple(defaults.keys()))
-    }
-
-
-@coerce_args_to_text
-@coerce_return_to_text
 def input_transaction_formatter(eth, txn):
     defaults = {
         'from': eth.defaultAccount,
@@ -89,6 +73,10 @@ def input_transaction_formatter(eth, txn):
     formatters = {
         'from': input_address_formatter,
         'to': input_address_formatter,
+        'value': from_decimal,
+        'gas': from_decimal,
+        'gasPrice': from_decimal,
+        'nonce': from_decimal,
     }
     return {
         key: formatters.get(key, identity)(txn.get(key, defaults.get(key)))


### PR DESCRIPTION
### What was wrong?

The `value`, `gas`, `gasPrice` and `nonce` for transactions was not being properly encoded as hex and parity got angry

### How was it fixed?

conform and encode those values as hex.

#### Cute Animal Picture

![Cute animal picture]()

