### PR TITLE
Closes #115 defaultAccount used as transaction from

### DIFF
--- a/tests/contracts/test_contract_transact_interface.py
+++ b/tests/contracts/test_contract_transact_interface.py
@@ -63,6 +63,30 @@ def test_transacting_with_contract_with_arguments(web3_tester,
     assert final_value - initial_value == 5
 
 
+def test_deploy_when_default_account_is_different_than_coinbase(web3_tester,
+                                                                STRING_CONTRACT):
+    web3_tester.eth.defaultAccount = web3_tester.eth.accounts[1]
+    assert web3_tester.eth.defaultAccount != web3_tester.eth.coinbase
+
+    StringContract = web3_tester.eth.contract(**STRING_CONTRACT)
+
+    deploy_txn = StringContract.deploy(args=["Caqalai"])
+    deploy_receipt = wait_for_transaction_receipt(web3_tester, deploy_txn, 30)
+    assert deploy_receipt['from'] == web3_tester.eth.defaultAccount
+
+
+def test_transact_when_default_account_is_different_than_coinbase(web3_tester,
+                                                                  math_contract,
+                                                                  transact_args,
+                                                                  transact_kwargs):
+    web3_tester.eth.defaultAccount = web3_tester.eth.accounts[1]
+    assert web3_tester.eth.defaultAccount != web3_tester.eth.coinbase
+
+    txn_hash = math_contract.transact().increment(*transact_args, **transact_kwargs)
+    txn_receipt = web3_tester.eth.getTransactionReceipt(txn_hash)
+    assert txn_receipt['from'] == web3_tester.eth.defaultAccount
+
+
 def test_transacting_with_contract_with_string_argument(web3_tester, string_contract):
     # eth_abi will pass as raw bytes, no encoding
     # unless we encode ourselves

--- a/tests/contracts/test_contract_transact_interface.py
+++ b/tests/contracts/test_contract_transact_interface.py
@@ -64,6 +64,7 @@ def test_transacting_with_contract_with_arguments(web3_tester,
 
 
 def test_deploy_when_default_account_is_different_than_coinbase(web3_tester,
+                                                                wait_for_transaction,
                                                                 STRING_CONTRACT):
     web3_tester.eth.defaultAccount = web3_tester.eth.accounts[1]
     assert web3_tester.eth.defaultAccount != web3_tester.eth.coinbase
@@ -71,20 +72,21 @@ def test_deploy_when_default_account_is_different_than_coinbase(web3_tester,
     StringContract = web3_tester.eth.contract(**STRING_CONTRACT)
 
     deploy_txn = StringContract.deploy(args=["Caqalai"])
-    deploy_receipt = wait_for_transaction_receipt(web3_tester, deploy_txn, 30)
-    assert deploy_receipt['from'] == web3_tester.eth.defaultAccount
+    wait_for_transaction(web3_tester, deploy_txn)
+    txn_after = web3_tester.eth.getTransaction(deploy_txn)
+    assert txn_after['from'] == web3_tester.eth.defaultAccount
 
 
 def test_transact_when_default_account_is_different_than_coinbase(web3_tester,
-                                                                  math_contract,
-                                                                  transact_args,
-                                                                  transact_kwargs):
+                                                                  wait_for_transaction,
+                                                                  math_contract):
     web3_tester.eth.defaultAccount = web3_tester.eth.accounts[1]
     assert web3_tester.eth.defaultAccount != web3_tester.eth.coinbase
 
-    txn_hash = math_contract.transact().increment(*transact_args, **transact_kwargs)
-    txn_receipt = web3_tester.eth.getTransactionReceipt(txn_hash)
-    assert txn_receipt['from'] == web3_tester.eth.defaultAccount
+    txn_hash = math_contract.transact().increment()
+    wait_for_transaction(web3_tester, txn_hash)
+    txn_after = web3_tester.eth.getTransaction(txn_hash)
+    assert txn_after['from'] == web3_tester.eth.defaultAccount
 
 
 def test_transacting_with_contract_with_string_argument(web3_tester, string_contract):

--- a/tests/contracts/test_contract_transact_interface.py
+++ b/tests/contracts/test_contract_transact_interface.py
@@ -99,19 +99,6 @@ def test_transacting_with_contract_with_string_argument(web3_tester, string_cont
     assert force_bytes(final_value) == force_bytes("ÄLÄMÖLÖ")
 
 
-def test_transacting_with_contract_with_string_argument(web3_tester, string_contract):
-
-    # eth_abi will pass as raw bytes, no encoding
-    # unless we encode ourselves
-    txn_hash = string_contract.transact().setValue(force_bytes("ÄLÄMÖLÖ"))
-    txn_receipt = web3_tester.eth.getTransactionReceipt(txn_hash)
-    assert txn_receipt is not None
-
-    final_value = string_contract.call().getValue()
-
-    assert force_bytes(final_value) == force_bytes("ÄLÄMÖLÖ")
-
-
 def test_transacting_with_contract_respects_explicit_gas(web3,
                                                          STRING_CONTRACT,
                                                          skip_if_testrpc,

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -434,7 +434,7 @@ class Contract(object):
 
         if self.address is not None:
             transact_transaction.setdefault('to', self.address)
-        transact_transaction.setdefault('from', self.web3.eth.coinbase)
+        transact_transaction.setdefault('from', self.web3.eth.defaultAccount)
 
         if 'to' not in transact_transaction:
             if isinstance(self, type):


### PR DESCRIPTION
https://github.com/pipermerriam/web3.py/issues/115

I have also removed a duplicate test (`test_transacting_with_contract_with_string_argument`)