### PR TITLE
fix for issue: 106

### DIFF
--- a/tests/filtering/test_filter_against_latest_blocks.py
+++ b/tests/filtering/test_filter_against_latest_blocks.py
@@ -16,9 +16,8 @@ def test_filter_against_latest_blocks(web3_empty, wait_for_block, skip_if_testrp
 
     wait_for_block(web3, current_block + 3)
 
-    with gevent.Timeout(5):
-        while len(seen_blocks) < 2:
-            gevent.sleep(random.random())
+    while len(seen_blocks) < 2:
+        pass
 
     txn_filter.stop_watching(3)
 

--- a/tests/filtering/test_filter_against_latest_blocks.py
+++ b/tests/filtering/test_filter_against_latest_blocks.py
@@ -16,8 +16,9 @@ def test_filter_against_latest_blocks(web3_empty, wait_for_block, skip_if_testrp
 
     wait_for_block(web3, current_block + 3)
 
-    while len(seen_blocks) < 2:
-        pass
+    with gevent.Timeout(5):
+        while len(seen_blocks) < 2:
+            gevent.sleep(random.random())
 
     txn_filter.stop_watching(3)
 

--- a/tests/filtering/test_filter_running_is_set_immediately.py
+++ b/tests/filtering/test_filter_running_is_set_immediately.py
@@ -1,0 +1,8 @@
+def test_filter_runs_immediately(web3):
+    seen_logs = []
+    txn_filter = web3.eth.filter({})
+    assert txn_filter.running is None
+
+    txn_filter.watch(lambda _: _)
+
+    assert txn_filter.running is True

--- a/tests/shh-module/test_shh_filter.py
+++ b/tests/shh-module/test_shh_filter.py
@@ -5,17 +5,15 @@ def test_shh_filter(web3, skip_if_testrpc):
     recieved_messages = []
     shh_filter = web3.shh.filter({"topics":[web3.fromAscii("test")]})
     shh_filter.watch(recieved_messages.append)
-    gevent.sleep(1)
     
     payloads = []
     payloads.append(str.encode("payload1"))
     web3.shh.post({"topics":[web3.fromAscii("test")], "payload":web3.fromAscii(payloads[len(payloads)-1])})
     gevent.sleep(1)
-    
+ 
     payloads.append(str.encode("payload2"))
     web3.shh.post({"topics":[web3.fromAscii("test")], "payload":web3.fromAscii(payloads[len(payloads)-1])})
     gevent.sleep(1)
-    
     assert len(recieved_messages) > 1
     
     for message in recieved_messages:

--- a/web3/utils/filters.py
+++ b/web3/utils/filters.py
@@ -108,6 +108,7 @@ class Filter(gevent.Greenlet):
 
         if not self.running:
             self.start()
+        gevent.sleep(0)
 
     def stop_watching(self, timeout=0):
         self.running = False


### PR DESCRIPTION
### What was wrong?
We had to explicitly yield the context after creating the filter


### How was it fixed?
Added a _gevent.sleep(0)_ inside _Filter.watch()_ method


#### Cute Animal Picture
![baby_panda](https://cloud.githubusercontent.com/assets/6094424/19634944/54f34212-99dc-11e6-968b-a3a354acbef0.jpg)


