### PR TITLE
Remove testrpc import requirement

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 pytest>=2.8.2
 pytest-pythonpath>=0.3
 tox>=1.8.0
+eth-testrpc>=0.9.0
 py-geth>=1.4.0
 ethereum>=1.5.2
 secp256k1>=0.13.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 pytest>=2.8.2
 pytest-pythonpath>=0.3
 tox>=1.8.0
-eth-testrpc>=0.9.0
 py-geth>=1.4.0
 ethereum>=1.5.2
 secp256k1>=0.13.1

--- a/tests/contracts/test_contract_estimateGas.py
+++ b/tests/contracts/test_contract_estimateGas.py
@@ -36,7 +36,7 @@ def test_contract_estimateGas(web3, math_contract):
     gas_estimate = math_contract.estimateGas().increment()
 
     try:
-        assert abs(gas_estimate - 21272) < 200  # Geth
+        assert abs(gas_estimate - 21472) < 200  # Geth
     except AssertionError:
-        assert abs(gas_estimate - 42820) < 200  # TestRPC
+        assert abs(gas_estimate - 43020) < 200  # TestRPC
         pass

--- a/tests/eth-module/test_eth_estimateGas.py
+++ b/tests/eth-module/test_eth_estimateGas.py
@@ -40,7 +40,7 @@ def test_eth_estimateGas(web3, math_contract):
     })
 
     try:
-        assert abs(gas_estimate - 21272) < 200  # Geth
+        assert abs(gas_estimate - 21472) < 200  # Geth
     except AssertionError:
-        assert abs(gas_estimate - 42820) < 200  # TestRPC
+        assert abs(gas_estimate - 43020) < 200  # TestRPC
         pass

--- a/web3/providers/tester.py
+++ b/web3/providers/tester.py
@@ -2,8 +2,6 @@ import logging
 
 import gevent
 
-from testrpc.rpc import RPCMethods
-
 from .base import BaseProvider  # noqa: E402
 from .rpc import RPCProvider  # noqa: E402
 
@@ -23,7 +21,8 @@ class EthereumTesterProvider(BaseProvider):
     def __init__(self,
                  *args,
                  **kwargs):
-        """Create a new RPC client.
+        """
+        Create a new RPC client.
 
         :param connection_timeout: See :class:`geventhttpclient.HTTPClient`
 
@@ -31,6 +30,8 @@ class EthereumTesterProvider(BaseProvider):
         """
         if not is_testrpc_available():
             raise Exception("`TestRPCProvider` requires the `eth-testrpc` package to be installed")
+        from testrpc.rpc import RPCMethods
+
         self.rpc_methods = RPCMethods()
         super(BaseProvider, self).__init__(*args, **kwargs)
 

--- a/web3/utils/exception_py2.py
+++ b/web3/utils/exception_py2.py
@@ -1,4 +1,5 @@
 import sys
 
+
 def raise_from(my_exception, other_exception):
     raise my_exception, None, sys.exc_info()[2]  # noqa: W602, E999


### PR DESCRIPTION
### What was wrong?

#140 

`eth-testrpc` should not be a hard requirement.

### How was it fixed?

Moved the import to within the classes that use it.

#### Cute Animal Picture

![baby bear](https://cloud.githubusercontent.com/assets/824194/21570549/16f7c334-ce84-11e6-9e2d-1bd0bd9c4054.jpeg)

