### PR TITLE
Fix transaction formatter to handle null

### DIFF
--- a/tests/eth-module/test_eth_getTransaction.py
+++ b/tests/eth-module/test_eth_getTransaction.py
@@ -1,0 +1,27 @@
+import pytest
+
+from web3.utils.string import force_bytes
+
+
+@pytest.fixture(autouse=True)
+def wait_for_first_block(web3, wait_for_block):
+    wait_for_block(web3)
+
+
+def test_eth_getTransaction_for_unknown_transaction(web3):
+    txn_hash = b'0xb903239f8543d04b5dc1ba6579132b143087c68db1b2168786408fcbce568238'
+    txn = web3.eth.getTransaction(txn_hash)
+    assert txn is None
+
+
+def test_eth_getTransaction(web3, extra_accounts, wait_for_transaction):
+    txn_hash = web3.eth.sendTransaction({
+        "from": web3.eth.coinbase,
+        "to": extra_accounts[1],
+        "value": 1234,
+    })
+
+    wait_for_transaction(web3, txn_hash)
+
+    txn = web3.eth.getTransaction(txn_hash)
+    assert txn['hash'] == txn_hash

--- a/web3/formatters.py
+++ b/web3/formatters.py
@@ -116,6 +116,7 @@ def input_transaction_formatter(eth, txn):
 
 @coerce_args_to_text
 @coerce_return_to_text
+@apply_if_not_null
 def output_transaction_formatter(txn):
     formatters = {
         'blockNumber': apply_if_not_null(to_decimal),


### PR DESCRIPTION
### What was wrong?

`eth.getTransaction` throws an exception if the hash is unknown.

### How was it fixed?

Fixed the formatter to properly handle null txn values.

#### Cute Animal Picture

![aardvark-born-busch-gardens-1-03072013](https://cloud.githubusercontent.com/assets/824194/21580529/f8ac95b6-cfba-11e6-90d8-00573371b263.jpeg)

