### PR TITLE
make HTTPProvider easier to import

### DIFF
--- a/web3/__init__.py
+++ b/web3/__init__.py
@@ -4,6 +4,7 @@ import pkg_resources
 
 from web3.main import Web3
 from web3.providers.rpc import (
+    HTTPProvider,
     RPCProvider,
     KeepAliveRPCProvider,
 )
@@ -20,6 +21,7 @@ __version__ = pkg_resources.get_distribution("web3").version
 __all__ = [
     "__version__",
     "Web3",
+    "HTTPProvider",
     "RPCProvider",
     "KeepAliveRPCProvider",
     "IPCProvider",

--- a/web3/main.py
+++ b/web3/main.py
@@ -14,6 +14,7 @@ from web3.testing import Testing
 from web3.iban import Iban
 
 from web3.providers.rpc import (
+    HTTPProvider,
     RPCProvider,
     KeepAliveRPCProvider,
 )
@@ -57,6 +58,7 @@ from web3.utils.address import (
 
 class Web3(object):
     # Providers
+    HTTPProvider = HTTPProvider
     RPCProvider = RPCProvider
     KeepAliveRPCProvider = KeepAliveRPCProvider
     IPCProvider = IPCProvider


### PR DESCRIPTION
### What was wrong?

`HTTPProvider` should be easy to import.

### How was it fixed?

Added it to `web3/__init__.py` and to the main `Web3` class.
