### PR TITLE
bugfix for request_kwargs in HTTPProvider

### DIFF
--- a/web3/providers/rpc.py
+++ b/web3/providers/rpc.py
@@ -30,7 +30,7 @@ class HTTPProvider(JSONBaseProvider):
     def get_request_kwargs(self):
         if 'headers' not in self._request_kwargs:
             yield 'headers', self.get_request_headers()
-        for key, value in self._request_kwargs:
+        for key, value in self._request_kwargs.items():
             yield key, value
 
     def get_request_headers(self):


### PR DESCRIPTION
### What was wrong?

Bad dictionary iteration in `HTTPProvider`

### How was it fixed?

Added `.items()`

#### Cute Animal Picture

![baby-camel-2](https://cloud.githubusercontent.com/assets/824194/22119205/ec514bf0-de37-11e6-9790-297f5bdc94cd.jpg)
