### PR TITLE
Add additional compiler fields to Contract object.

### DIFF
--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -8,7 +8,7 @@ Contracts
 Contract Factories
 ------------------
 
-.. py:class:: Contract(abi, address=None, code=None, code_runtime=None, source=None)
+.. py:class:: Contract(address)
 
     The ``Contract`` class is not intended to be used or instantiated directly.
     Instead you should use the ``web3.eth.contract(...)`` method to generate
@@ -35,19 +35,19 @@ Each Contract Factory exposes the following properties.
     The contract ABI array.
 
 
-.. py:attribute:: Contract.code
+.. py:attribute:: Contract.bytecode
 
     The contract bytecode string.  May be ``None`` if not provided during
     factory creation.
 
 
-.. py:attribute:: Contract.code_runtime
+.. py:attribute:: Contract.bytecode_runtime
 
     The runtime part of the contract bytecode string.  May be ``None`` if not
     provided during factory creation.
 
 
-.. py:attribute:: Contract.code_runtime
+.. py:attribute:: Contract.bytecode_runtime
 
     The runtime part of the contract bytecode string.  May be ``None`` if not
     provided during factory creation.

--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -579,22 +579,31 @@ with the filtering API.
 Contracts
 ---------
 
-.. py:method:: Eth.contract(abi, address=None, code=None, code_runtime=None, source=None)
+.. py:method:: Eth.contract(address=None, contract_name=None, ContractFactoryClass=Contract, **contract_factory_kwargs)
 
     If ``address`` is provided then this method will return an instance of the
-    contract defined by ``abi``.
+    contract defined by ``abi``.  Otherwise the newly created contract class
+    will be returned.
 
-    If ``address`` is ``None`` then this method will return a Contract Factory,
-    which can be though of as the python class that represents your contract.
+    ``contract_name`` will be used as the name of the contract class.  If
+    ``None`` then the name of the ``ContractFactoryClass`` will be used.
 
-    The ``abi`` parameter should be an array containing the ABI definition of
-    the contract functions and events.
+    ``ContractFactoryClass`` will be used as the base Contract class.
 
-    The ``code`` parameter should be the full contract bytecode.
+    The following arguments are accepted for contract class creation.
 
-    The ``code_runtime`` parameter should be the runtime part of the contract bytecode.
-
-    The ``source`` parameter should be a string containing the full source code
-    of the contract.
+    - ``abi``
+    - ``asm``
+    - ``ast``
+    - ``bytecode``
+    - ``bytecode_runtime``
+    - ``clone_bin``
+    - ``dev_doc``
+    - ``interface``
+    - ``metadata``
+    - ``opcodes``
+    - ``src_map``
+    - ``src_map_runtime``
+    - ``user_doc``
 
     See :doc:`./contracts` for more information about how to use contracts.

--- a/tests/contracts/conftest.py
+++ b/tests/contracts/conftest.py
@@ -74,8 +74,8 @@ def MATH_ABI():
 def MathContract(web3, MATH_ABI, MATH_CODE, MATH_RUNTIME, MATH_SOURCE):
     return web3.eth.contract(
         abi=MATH_ABI,
-        code=MATH_CODE,
-        code_runtime=MATH_RUNTIME,
+        bytecode=MATH_CODE,
+        bytecode_runtime=MATH_RUNTIME,
         source=MATH_SOURCE,
     )
 
@@ -114,8 +114,8 @@ def SimpleConstructorContract(web3,
                               SIMPLE_CONSTRUCTOR_ABI):
     return web3.eth.contract(
         abi=SIMPLE_CONSTRUCTOR_ABI,
-        code=SIMPLE_CONSTRUCTOR_CODE,
-        code_runtime=SIMPLE_CONSTRUCTOR_RUNTIME,
+        bytecode=SIMPLE_CONSTRUCTOR_CODE,
+        bytecode_runtime=SIMPLE_CONSTRUCTOR_RUNTIME,
         source=SIMPLE_CONSTRUCTOR_SOURCE,
     )
 
@@ -155,8 +155,8 @@ def WithConstructorArgumentsContract(web3,
                                      WITH_CONSTRUCTOR_ARGUMENTS_ABI):
     return web3.eth.contract(
         abi=WITH_CONSTRUCTOR_ARGUMENTS_ABI,
-        code=WITH_CONSTRUCTOR_ARGUMENTS_CODE,
-        code_runtime=WITH_CONSTRUCTOR_ARGUMENTS_RUNTIME,
+        bytecode=WITH_CONSTRUCTOR_ARGUMENTS_CODE,
+        bytecode_runtime=WITH_CONSTRUCTOR_ARGUMENTS_RUNTIME,
         source=WITH_CONSTRUCTOR_ARGUMENTS_SOURCE,
     )
 
@@ -195,8 +195,8 @@ def WithConstructorAddressArgumentsContract(web3,
                                             WITH_CONSTRUCTOR_ADDRESS_ABI):
     return web3.eth.contract(
         abi=WITH_CONSTRUCTOR_ADDRESS_ABI,
-        code=WITH_CONSTRUCTOR_ADDRESS_CODE,
-        code_runtime=WITH_CONSTRUCTOR_ADDRESS_RUNTIME,
+        bytecode=WITH_CONSTRUCTOR_ADDRESS_CODE,
+        bytecode_runtime=WITH_CONSTRUCTOR_ADDRESS_RUNTIME,
         source=WITH_CONSTRUCTOR_ADDRESS_SOURCE,
     )
 
@@ -255,8 +255,8 @@ def STRING_ABI():
 @pytest.fixture()
 def STRING_CONTRACT(STRING_SOURCE, STRING_CODE, STRING_RUNTIME, STRING_ABI):
     return {
-        'code': STRING_CODE,
-        'code_runtime': STRING_RUNTIME,
+        'bytecode': STRING_CODE,
+        'bytecode_runtime': STRING_RUNTIME,
         'abi': STRING_ABI,
         'source': STRING_SOURCE,
     }
@@ -382,8 +382,8 @@ def EMITTER(EMITTER_CODE,
             EMITTER_ABI,
             EMITTER_SOURCE):
     return {
-        'code': EMITTER_CODE,
-        'code_runtime': EMITTER_RUNTIME,
+        'bytecode': EMITTER_CODE,
+        'bytecode_runtime': EMITTER_RUNTIME,
         'source': EMITTER_SOURCE,
         'abi': EMITTER_ABI,
     }
@@ -404,8 +404,8 @@ def emitter(web3_empty, Emitter, wait_for_transaction, wait_for_block):
     deploy_receipt = wait_for_transaction(web3, deploy_txn_hash)
     contract_address = deploy_receipt['contractAddress']
 
-    code = web3.eth.getCode(contract_address)
-    assert code == Emitter.code_runtime
+    bytecode = web3.eth.getCode(contract_address)
+    assert bytecode == Emitter.bytecode_runtime
     return Emitter(address=contract_address)
 
 

--- a/tests/contracts/test_contract_class_construction.py
+++ b/tests/contracts/test_contract_class_construction.py
@@ -7,14 +7,14 @@ def test_class_construction_sets_class_vars(web3, MATH_ABI, MATH_CODE,
                                             MATH_RUNTIME, MATH_SOURCE):
     MathContract = web3.eth.contract(
         abi=MATH_ABI,
-        code=MATH_CODE,
-        code_runtime=MATH_RUNTIME,
+        bytecode=MATH_CODE,
+        bytecode_runtime=MATH_RUNTIME,
         source=MATH_SOURCE,
     )
 
     assert MathContract.web3 == web3
-    assert MathContract.code == MATH_CODE
-    assert MathContract.code_runtime == MATH_RUNTIME
+    assert MathContract.bytecode == MATH_CODE
+    assert MathContract.bytecode_runtime == MATH_RUNTIME
     assert MathContract.source == MATH_SOURCE
 
 

--- a/tests/contracts/test_contract_estimateGas.py
+++ b/tests/contracts/test_contract_estimateGas.py
@@ -15,8 +15,8 @@ def math_contract(web3, MATH_ABI, MATH_CODE, MATH_RUNTIME, MATH_SOURCE,
                   wait_for_transaction):
     MathContract = web3.eth.contract(
         abi=MATH_ABI,
-        code=MATH_CODE,
-        code_runtime=MATH_RUNTIME,
+        bytecode=MATH_CODE,
+        bytecode_runtime=MATH_RUNTIME,
         source=MATH_SOURCE,
     )
     deploy_txn = MathContract.deploy({'from': web3.eth.coinbase})

--- a/tests/contracts/test_extracting_event_data.py
+++ b/tests/contracts/test_extracting_event_data.py
@@ -23,8 +23,8 @@ def emitter(web3, Emitter, wait_for_transaction, wait_for_block):
     deploy_receipt = wait_for_transaction(web3, deploy_txn_hash)
     contract_address = deploy_receipt['contractAddress']
 
-    code = web3.eth.getCode(contract_address)
-    assert code == Emitter.code_runtime
+    bytecode = web3.eth.getCode(contract_address)
+    assert bytecode == Emitter.bytecode_runtime
     return Emitter(address=contract_address)
 
 

--- a/tests/contracts/test_legacy_constructor_adapter.py
+++ b/tests/contracts/test_legacy_constructor_adapter.py
@@ -30,14 +30,18 @@ class ContactClassForTest(Contract):
         ((ABI,), {'abi': ABI}, TypeError),
         ((ABI, ADDRESS), {}, {'abi': ABI, 'address': ADDRESS}),
         (
+            (ABI, ADDRESS),
+            {'code': '0x1', 'code_runtime': '0x2'},
+            {'abi': ABI, 'address': ADDRESS, 'bytecode': '0x1', 'bytecode_runtime': '0x2'}),
+        (
             (ABI, ADDRESS, '0x1', '0x2', '0x3'),
             {},
-            {'abi': ABI, 'address': ADDRESS, 'binary': '0x1', 'binary_runtime': '0x2', 'source': '0x3'},
+            {'abi': ABI, 'address': ADDRESS, 'bytecode': '0x1', 'bytecode_runtime': '0x2', 'source': '0x3'},
         ),
         (
             tuple(),
             {'abi': ABI, 'address': ADDRESS, 'code': '0x1', 'code_runtime': '0x2', 'source': '0x3'},
-            {'abi': ABI, 'address': ADDRESS, 'binary': '0x1', 'binary_runtime': '0x2', 'source': '0x3'},
+            {'abi': ABI, 'address': ADDRESS, 'bytecode': '0x1', 'bytecode_runtime': '0x2', 'source': '0x3'},
         ),
         ((ABI, ADDRESS), {'abi': ABI}, TypeError),
         ((ABI, ADDRESS), {'address': ADDRESS}, TypeError),

--- a/tests/contracts/test_legacy_constructor_adapter.py
+++ b/tests/contracts/test_legacy_constructor_adapter.py
@@ -1,0 +1,90 @@
+import pytest
+import warnings
+
+from web3.contract import (
+    Contract,
+)
+
+
+ABI = [
+    {
+        "constant": False,
+        "inputs": [],
+        "name": "func_1",
+        "outputs": [],
+        "type": "function",
+    },
+]
+
+ADDRESS = '0x0000000000000000000000000000000000000000'
+
+
+class ContactClassForTest(Contract):
+    web3 = True
+
+
+@pytest.mark.parametrize(
+    'args,kwargs,expected',
+    (
+        ((ABI,), {}, {'abi': ABI}),
+        ((ABI,), {'abi': ABI}, TypeError),
+        ((ABI, ADDRESS), {}, {'abi': ABI, 'address': ADDRESS}),
+        (
+            (ABI, ADDRESS, '0x1', '0x2', '0x3'),
+            {},
+            {'abi': ABI, 'address': ADDRESS, 'binary': '0x1', 'binary_runtime': '0x2', 'source': '0x3'},
+        ),
+        (
+            tuple(),
+            {'abi': ABI, 'address': ADDRESS, 'code': '0x1', 'code_runtime': '0x2', 'source': '0x3'},
+            {'abi': ABI, 'address': ADDRESS, 'binary': '0x1', 'binary_runtime': '0x2', 'source': '0x3'},
+        ),
+        ((ABI, ADDRESS), {'abi': ABI}, TypeError),
+        ((ABI, ADDRESS), {'address': ADDRESS}, TypeError),
+        ((ADDRESS,), {}, {'address': ADDRESS}),
+    )
+)
+def test_process_legacy_constructor_signature(args, kwargs, expected):
+
+    if isinstance(expected, type) and issubclass(expected, Exception):
+        with pytest.raises(expected):
+            ContactClassForTest(*args, **kwargs)
+        return
+
+    actual = ContactClassForTest(*args, **kwargs)
+    for key, value in expected.items():
+        assert getattr(actual, key) == value
+
+
+def test_deprecated_properties():
+    instance = ContactClassForTest(ABI, ADDRESS, '0x1', '0x2', '0x3')
+
+    with pytest.warns(DeprecationWarning):
+        instance.code
+
+    with pytest.warns(DeprecationWarning):
+        instance.code_runtime
+
+    with pytest.warns(DeprecationWarning):
+        instance.source
+
+
+def test_deprecated_instantiation():
+    with pytest.warns(Warning) as record:
+        ContactClassForTest(ADDRESS)
+        ContactClassForTest(address=ADDRESS)
+        warnings.warn(Warning('test'))
+
+    assert len(record) == 1
+
+    with pytest.warns(DeprecationWarning):
+        ContactClassForTest()  # no address
+
+    with pytest.warns(DeprecationWarning):
+        ContactClassForTest(ABI, ADDRESS)  # no address
+
+    with pytest.warns(DeprecationWarning):
+        ContactClassForTest(ABI)  # no address
+
+    with pytest.warns(DeprecationWarning):
+        ContactClassForTest(code='0x1')  # no address

--- a/tests/contracts/test_legacy_constructor_adapter.py
+++ b/tests/contracts/test_legacy_constructor_adapter.py
@@ -1,5 +1,6 @@
 import pytest
 import warnings
+import sys
 
 from web3.contract import (
     Contract,
@@ -60,8 +61,12 @@ def test_process_legacy_constructor_signature(args, kwargs, expected):
         assert getattr(actual, key) == value
 
 
+@pytest.mark.skipif(sys.version_info.major == 2, reason="Python2 fails weirdly on this test")
 def test_deprecated_properties():
-    instance = ContactClassForTest(ABI, ADDRESS, '0x1', '0x2', '0x3')
+    instance = ContactClassForTest(ABI, ADDRESS, '0x1', '0x2', source='0x3')
+
+    with pytest.warns(DeprecationWarning):
+        instance.source
 
     with pytest.warns(DeprecationWarning):
         instance.code
@@ -69,10 +74,8 @@ def test_deprecated_properties():
     with pytest.warns(DeprecationWarning):
         instance.code_runtime
 
-    with pytest.warns(DeprecationWarning):
-        instance.source
 
-
+@pytest.mark.skipif(sys.version_info.major == 2, reason="Python2 fails weirdly on this test")
 def test_deprecated_instantiation():
     with pytest.warns(Warning) as record:
         ContactClassForTest(ADDRESS)

--- a/tests/empty-object/test_empty_object_is_falsy.py
+++ b/tests/empty-object/test_empty_object_is_falsy.py
@@ -1,0 +1,8 @@
+from web3.utils.empty import (
+    empty,
+)
+
+
+def test_empty_object_is_falsy():
+    assert bool(empty) is False
+    assert not empty

--- a/tests/eth-module/test_eth_estimateGas.py
+++ b/tests/eth-module/test_eth_estimateGas.py
@@ -15,8 +15,8 @@ def math_contract(web3, MATH_ABI, MATH_CODE, MATH_RUNTIME, MATH_SOURCE,
                   wait_for_transaction):
     MathContract = web3.eth.contract(
         abi=MATH_ABI,
-        code=MATH_CODE,
-        code_runtime=MATH_RUNTIME,
+        bytecode=MATH_CODE,
+        bytecode_runtime=MATH_RUNTIME,
         source=MATH_SOURCE,
     )
     deploy_txn = MathContract.deploy({'from': web3.eth.coinbase})

--- a/tests/filtering/conftest.py
+++ b/tests/filtering/conftest.py
@@ -123,8 +123,8 @@ def EMITTER(EMITTER_CODE,
             EMITTER_ABI,
             EMITTER_SOURCE):
     return {
-        'code': EMITTER_CODE,
-        'code_runtime': EMITTER_RUNTIME,
+        'bytecode': EMITTER_CODE,
+        'bytecode_runtime': EMITTER_RUNTIME,
         'source': EMITTER_SOURCE,
         'abi': EMITTER_ABI,
     }
@@ -142,8 +142,8 @@ def emitter(web3, Emitter, wait_for_transaction, wait_for_block):
     deploy_receipt = wait_for_transaction(web3, deploy_txn_hash)
     contract_address = deploy_receipt['contractAddress']
 
-    code = web3.eth.getCode(contract_address)
-    assert code == Emitter.code_runtime
+    bytecode = web3.eth.getCode(contract_address)
+    assert bytecode == Emitter.bytecode_runtime
     return Emitter(address=contract_address)
 
 

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -107,8 +107,8 @@ class Contract(object):
     asm = None
     ast = None
 
-    binary = None
-    binary_runtime = None
+    bytecode = None
+    bytecode_runtime = None
     clone_bin = None
 
     dev_doc = None
@@ -129,10 +129,6 @@ class Contract(object):
         """Create a new smart contract proxy object.
 
         :param address: Contract address as 0x hex string
-        :param abi: Override class level definition
-        :param code: Override class level definition
-        :param code_runtime: Override class level definition
-        :param source: Override class level definition
         """
         if self.web3 is None:
             raise AttributeError(
@@ -185,9 +181,9 @@ class Contract(object):
         if abi is not empty:
             self.abi = abi
         if code is not empty:
-            self.binary = code
+            self.bytecode = code
         if code_runtime is not empty:
-            self.binary_runtime = code_runtime
+            self.bytecode_runtime = code_runtime
         if source is not empty:
             self._source = source
 
@@ -224,22 +220,22 @@ class Contract(object):
     def code(self):
         warnings.warn(DeprecationWarning(
             "The `code` property has been deprecated.  You should update your "
-            "code to access this value through `contract.binary`.  The `code` "
+            "code to access this value through `contract.bytecode`.  The `code` "
             "property will be removed in future releases"
         ))
-        if self.binary is not None:
-            return self.binary
+        if self.bytecode is not None:
+            return self.bytecode
         raise AttributeError("No contract code was specified for thes contract")
 
     @property
     def code_runtime(self):
         warnings.warn(DeprecationWarning(
             "The `code_runtime` property has been deprecated.  You should update your "
-            "code to access this value through `contract.binary_runtime`.  The `code_runtime` "
+            "code to access this value through `contract.bytecode_runtime`.  The `code_runtime` "
             "property will be removed in future releases"
         ))
-        if self.binary_runtime is not None:
-            return self.binary_runtime
+        if self.bytecode_runtime is not None:
+            return self.bytecode_runtime
         raise AttributeError("No contract code_runtime was specified for thes contract")
 
     @property
@@ -287,9 +283,9 @@ class Contract(object):
         else:
             deploy_transaction = dict(**transaction)
 
-        if not cls.code:
+        if not cls.bytecode:
             raise ValueError(
-                "Cannot deploy a contract that does not have 'code' associated "
+                "Cannot deploy a contract that does not have 'bytecode' associated "
                 "with it"
             )
 
@@ -740,10 +736,10 @@ class Contract(object):
             arguments = merge_args_and_kwargs(constructor_abi, args, kwargs)
 
             deploy_data = add_0x_prefix(
-                cls._encode_abi(constructor_abi, arguments, data=cls.code)
+                cls._encode_abi(constructor_abi, arguments, data=cls.bytecode)
             )
         else:
-            deploy_data = add_0x_prefix(cls.code)
+            deploy_data = add_0x_prefix(cls.bytecode)
 
         return deploy_data
 

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -16,24 +16,6 @@ from web3.exceptions import (
     BadFunctionCallOutput,
 )
 
-from web3.utils.encoding import (
-    encode_hex,
-)
-from web3.utils.exception import (
-    raise_from,
-)
-from web3.utils.formatting import (
-    add_0x_prefix,
-    remove_0x_prefix,
-)
-from web3.utils.string import (
-    force_bytes,
-    coerce_return_to_text,
-    force_obj_to_bytes,
-)
-from web3.utils.functional import (
-    compose,
-)
 from web3.utils.abi import (
     filter_by_type,
     filter_by_name,
@@ -51,12 +33,33 @@ from web3.utils.abi import (
 from web3.utils.decorators import (
     combomethod,
 )
+from web3.utils.empty import (
+    empty,
+)
+from web3.utils.encoding import (
+    encode_hex,
+)
 from web3.utils.events import (
     get_event_data,
+)
+from web3.utils.exception import (
+    raise_from,
 )
 from web3.utils.filters import (
     construct_event_filter_params,
     PastLogFilter,
+)
+from web3.utils.formatting import (
+    add_0x_prefix,
+    remove_0x_prefix,
+)
+from web3.utils.functional import (
+    compose,
+)
+from web3.utils.string import (
+    force_bytes,
+    coerce_return_to_text,
+    force_obj_to_bytes,
 )
 
 
@@ -90,11 +93,13 @@ class Contract(object):
     address = None
 
     def __init__(self,
-                 abi=None,
-                 address=None,
-                 code=None,
-                 code_runtime=None,
-                 source=None):
+                 abi=empty,
+                 address=empty,
+                 code=empty,
+                 bytecode=empty,
+                 runtime=empty,
+                 code_runtime=empty,
+                 source=empty):
         """Create a new smart contract proxy object.
 
         :param address: Contract address as 0x hex string
@@ -103,18 +108,18 @@ class Contract(object):
         :param code_runtime: Override class level definition
         :param source: Override class level definition
         """
-        if self.web3 is None:
+        if self.web3 is empty:
             raise AttributeError(
                 'The `Contract` class has not been initialized.  Please use the '
                 '`web3.contract` interface to create your contract class.'
             )
-        if abi is not None:
+        if abi is not empty:
             self._abi = abi
-        if code is not None:
+        if code is not empty:
             self._code = code
-        if code_runtime is not None:
+        if code_runtime is not empty:
             self._code_runtime = code_runtime
-        if source is not None:
+        if source is not empty:
             self._source = source
 
         self.address = address

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -564,6 +564,8 @@ class Contract(object):
                              transaction=None):
         """
         Returns a dictionary of the transaction that could be used to call this
+        TODO: make this a public API
+        TODO: add new prepare_deploy_transaction API
         """
         if transaction is None:
             prepared_transaction = {}

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -121,15 +121,17 @@ class Contract(object):
 
     def __init__(self,
                  *args,
-                 code=empty,
-                 code_runtime=empty,
-                 source=empty,
-                 abi=empty,
-                 address=empty):
+                 **kwargs):
         """Create a new smart contract proxy object.
 
         :param address: Contract address as 0x hex string
         """
+        code = kwargs.pop('code', empty)
+        code_runtime = kwargs.pop('code_runtime', empty)
+        source = kwargs.pop('source', empty)
+        abi = kwargs.pop('abi', empty)
+        address = kwargs.pop('address', empty)
+
         if self.web3 is None:
             raise AttributeError(
                 'The `Contract` class has not been initialized.  Please use the '
@@ -155,17 +157,17 @@ class Contract(object):
                 raise TypeError("The 'address' argument was found twice")
             address = arg_1
 
-        if arg_2:
+        if arg_2 is not empty:
             if code:
                 raise TypeError("The 'code' argument was found twice")
             code = arg_2
 
-        if arg_3:
+        if arg_3 is not empty:
             if code_runtime:
                 raise TypeError("The 'code_runtime' argument was found twice")
             code_runtime = arg_3
 
-        if arg_4:
+        if arg_4 is not empty:
             if source:
                 raise TypeError("The 'source' argument was found twice")
             source = arg_4

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -341,9 +341,10 @@ class Eth(object):
 
     def contract(self,
                  *args,
-                 contract_name=None,
-                 ContractFactoryClass=Contract,
                  **kwargs):
+        ContractFactoryClass = kwargs.pop('ContractFactoryClass', Contract)
+        contract_name = kwargs.pop('contract_name', None)
+
         has_address = any((
             'address' in kwargs,
             len(args) >= 1 and is_address(args[0]),
@@ -359,13 +360,13 @@ class Eth(object):
                 address = args[1]
                 kwargs['abi'] = args[0]
 
-            return Contract.factory(self.web3, contract_name, **kwargs)(address)
+            return ContractFactoryClass.factory(self.web3, contract_name, **kwargs)(address)
         else:
             try:
                 kwargs['abi'] = args[0]
             except IndexError:
                 pass
-            return Contract.factory(self.web3, contract_name, **kwargs)
+            return ContractFactoryClass.factory(self.web3, contract_name, **kwargs)
 
     def getCompilers(self):
         return self.web3._requestManager.request_blocking("eth_getCompilers", [])

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -1,32 +1,33 @@
 from web3 import formatters
 from web3.iban import Iban
 
+from web3.contract import construct_contract_factory
+
+from web3.utils.blocks import (
+    is_predefined_block_number,
+)
 from web3.utils.encoding import (
     to_decimal,
     encode_hex,
-)
-from web3.utils.types import (
-    is_integer,
-    is_string,
-)
-from web3.utils.string import (
-    coerce_return_to_text,
-)
-from web3.utils.functional import (
-    apply_formatters_to_return,
-)
-from web3.utils.transactions import (
-    get_buffered_gas_estimate,
 )
 from web3.utils.filters import (
     BlockFilter,
     TransactionFilter,
     LogFilter,
 )
-from web3.utils.blocks import (
-    is_predefined_block_number,
+from web3.utils.functional import (
+    apply_formatters_to_return,
 )
-from web3.contract import construct_contract_factory
+from web3.utils.string import (
+    coerce_return_to_text,
+)
+from web3.utils.transactions import (
+    get_buffered_gas_estimate,
+)
+from web3.utils.types import (
+    is_integer,
+    is_string,
+)
 
 
 class Eth(object):
@@ -42,6 +43,7 @@ class Eth(object):
     def defaultAccount(self):
         if self._defaultAccount is not None:
             return self._defaultAccount
+        # TODO: deprecate defaulting to the coinbase for the from address.
         return self.coinbase
 
     @defaultAccount.setter

--- a/web3/main.py
+++ b/web3/main.py
@@ -31,12 +31,14 @@ from web3.providers.manager import (
     PrivateKeySigningManager,
 )
 
-from web3.utils.functional import (
-    compose,
+from web3.utils.address import (
+    is_address,
+    is_checksum_address,
+    to_checksum_address,
 )
-from web3.utils.string import (
-    force_text,
-    coerce_return_to_text,
+from web3.utils.currency import (
+    to_wei,
+    from_wei,
 )
 from web3.utils.encoding import (
     to_hex,
@@ -45,14 +47,12 @@ from web3.utils.encoding import (
     to_decimal,
     from_decimal,
 )
-from web3.utils.currency import (
-    to_wei,
-    from_wei,
+from web3.utils.functional import (
+    compose,
 )
-from web3.utils.address import (
-    is_address,
-    is_checksum_address,
-    to_checksum_address,
+from web3.utils.string import (
+    force_text,
+    coerce_return_to_text,
 )
 
 

--- a/web3/utils/empty.py
+++ b/web3/utils/empty.py
@@ -1,0 +1,2 @@
+class empty(object):
+    pass

--- a/web3/utils/empty.py
+++ b/web3/utils/empty.py
@@ -1,2 +1,9 @@
-class empty(object):
-    pass
+class Empty(object):
+    def __bool__(self):
+        return False
+
+    def __nonzero__(self):
+        return False
+
+
+empty = Empty()


### PR DESCRIPTION
### What was wrong?

* Contracts used the term `code` and `code_runtime` which wasn't congruent with terminology used elsewhere.
* Contracts didn't accept any extra properties.

### How was it fixed?

* Deprecated `code` and `code_runtime` in place of `binary` and `binary_runtime`
* Add all the other fields that the solidity compiler puts out.

#### Cute Animal Picture

![Uploading animal-baby-animal-baby-pony-cute-foal-Favim.com-345532.jpeg…]()
