### PR TITLE
IPC via named pipe on Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ language: python
 python:
   - "3.5"
 dist: trusty
-sudo: required
-before_install:
-  - travis_retry sudo add-apt-repository -y ppa:ethereum/ethereum
-  - travis_retry sudo apt-get update
 env:
   matrix:
     - TOX_ENV=py27-stdlib

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,17 @@ DIR = os.path.dirname(os.path.abspath(__file__))
 
 readme = open(os.path.join(DIR, 'README.md')).read()
 
+install_requires=[
+    "ethereum-abi-utils>=0.4.0",
+    "ethereum-utils>=0.2.0",
+    "pylru>=1.0.9",
+    "pysha3>=0.3",
+    "requests>=2.12.4",
+    "rlp>=0.4.6,<0.4.7",
+],
+import sys
+if sys.platform == 'win32':
+    install_requires.append('pypiwin32')
 
 setup(
     name='web3',
@@ -23,14 +34,7 @@ setup(
     author_email='pipermerriam@gmail.com',
     url='https://github.com/pipermerriam/web3.py',
     include_package_data=True,
-    install_requires=[
-        "ethereum-abi-utils>=0.4.0",
-        "ethereum-utils>=0.2.0",
-        "pylru>=1.0.9",
-        "pysha3>=0.3",
-        "requests>=2.12.4",
-        "rlp>=0.4.6,<0.4.7",
-    ],
+    install_requires=install_requires,
     extras_require={
         'Tester': ["eth-testrpc>=1.1.0"],
         'tester': ["eth-testrpc>=1.1.0"],

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import os
+import sys
 
 from setuptools import (
     setup,
@@ -20,8 +21,8 @@ install_requires=[
     "pysha3>=0.3",
     "requests>=2.12.4",
     "rlp>=0.4.6,<0.4.7",
-],
-import sys
+]
+
 if sys.platform == 'win32':
     install_requires.append('pypiwin32')
 

--- a/web3/utils/windows.py
+++ b/web3/utils/windows.py
@@ -1,0 +1,31 @@
+import sys
+
+
+if sys.platform != 'win32':
+    raise ImportError("This module should not be imported on non `win32` platforms")
+
+
+import win32file  # noqa: E402
+import pywintypes  # noqa: E402
+
+
+class NamedPipe(object):
+    def __init__(self, ipc_path):
+        try:
+            self.handle = win32file.CreateFile(
+                ipc_path, win32file.GENERIC_READ | win32file.GENERIC_WRITE,
+                0, None, win32file.OPEN_EXISTING, 0, None)
+        except pywintypes.error as err:
+            raise IOError(err)
+
+    def recv(self, max_length):
+        (err, data) = win32file.ReadFile(self.handle, max_length)
+        if err:
+            raise IOError(err)
+        return data
+
+    def sendall(self, data):
+        return win32file.WriteFile(self.handle, data)
+
+    def close(self):
+        self.handle.close()


### PR DESCRIPTION
This PR implements IPC on Windows by named pipe. The design is not very beautiful, but works for basic cases we tested. Unfortunately, there are no functional test that check communicate with real Ethereum client.

Definitely, Windows support is better than it was.

Resolves #17 
