### PR TITLE
Added function type support 

### DIFF
--- a/web3/utils/abi.py
+++ b/web3/utils/abi.py
@@ -112,6 +112,12 @@ def is_encodable(_type, value):
         if not is_address(value):
             return False
         return True
+    elif base == 'function':
+        if not is_string(value):
+            return False
+        if not len(value) == 24:
+            return False
+        return True
     else:
         raise ValueError("Unsupported type")
 


### PR DESCRIPTION
Issue #164

### What was wrong?
The function variable type (introduced here ethereum/solidity#1122) was not supported by web3.py. 

### How was it fixed?
Added a new "function" type into web3/utils/abi.py modelled after the bytes24 type (as specified in http://solidity.readthedocs.io/en/develop/types.html)