### PR TITLE
See if things explode with pyrlp 0.4.7

### DIFF
--- a/docs/managers.rst
+++ b/docs/managers.rst
@@ -21,6 +21,7 @@ RequestManager
 Delegated Signing Manager
 -------------------------
 
+.. warning:: The ``DelegatedSigningManager`` has been deprecated and will be removed in subsequent releases.
 
 .. py:class:: DelegatedSigningManager(wrapped_manager, signing_manager)
 
@@ -67,6 +68,8 @@ transaction to the network using the ``eth_sendRawTransaction`` method.
 
 Private Key Signing Manager
 ---------------------------
+
+.. warning:: The ``PrivateKeySigningManager`` has been deprecated and will be removed in subsequent releases.
 
 .. py:class:: PrivateKeySigningManager(wrapped_manager, keys={})
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,8 @@
 pytest>=2.8.2
 pytest-pythonpath>=0.3
 tox>=1.8.0
-eth-testrpc>=1.1.0
-ethereum>=1.5.2
+eth-testrpc>=1.2.0
+ethereum>=1.6.1
 secp256k1>=0.13.1
 hypothesis>=3.4.2
 flaky>=3.3.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,6 @@ tox>=1.8.0
 eth-testrpc>=1.1.0
 ethereum>=1.5.2
 secp256k1>=0.13.1
-rlp>=0.4.6,<0.4.7
 hypothesis>=3.4.2
 flaky>=3.3.0
 flake8==3.0.4

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ install_requires=[
     "pylru>=1.0.9",
     "pysha3>=0.3",
     "requests>=2.12.4",
-    "rlp>=0.4.6",
+    "rlp>=0.4.7",
 ]
 
 if sys.platform == 'win32':
@@ -37,8 +37,7 @@ setup(
     include_package_data=True,
     install_requires=install_requires,
     extras_require={
-        'Tester': ["eth-testrpc>=1.1.0"],
-        'tester': ["eth-testrpc>=1.1.0"],
+        'tester': ["eth-testrpc>=1.2.0"],
         'gevent': [
             "gevent>=1.1.1,<1.2.0",
             "geventhttpclient>=1.3.1",

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ install_requires=[
     "pylru>=1.0.9",
     "pysha3>=0.3",
     "requests>=2.12.4",
-    "rlp>=0.4.6,<0.4.7",
+    "rlp>=0.4.6",
 ]
 
 if sys.platform == 'win32':

--- a/web3/providers/manager.py
+++ b/web3/providers/manager.py
@@ -1,17 +1,18 @@
-import uuid
-import json
 import collections
+import json
+import uuid
+import warnings
 
 import rlp
 
 from eth_utils import (
-    force_text,
-    to_normalized_address,
-    is_string,
-    is_dict,
-    encode_hex,
     decode_hex,
+    encode_hex,
+    force_text,
+    is_dict,
+    is_string,
     keccak,
+    to_normalized_address,
 )
 
 from web3.utils.encoding import (
@@ -82,6 +83,10 @@ class RequestManager(object):
 
 class ManagerWrapper(object):
     def __init__(self, wrapped_manager):
+        warnings.warn(DeprecationWarning(
+            "ManagerWrapper has been deprecated and will be removed from"
+            "web3.py in subsequen releases."
+        ))
         self.wrapped_manager = wrapped_manager
 
     @property
@@ -223,6 +228,10 @@ class BaseSendRawTransactionMixin(ManagerWrapper):
 
 class DelegatedSigningManager(BaseSendRawTransactionMixin):
     def __init__(self, *args, **kwargs):
+        warnings.warn(DeprecationWarning(
+            "DelegatedSigningManager has been deprecated and will be removed from"
+            "web3.py in subsequen releases."
+        ))
         self.signing_manager = kwargs.pop('signing_manager')
         super(DelegatedSigningManager, self).__init__(*args, **kwargs)
 
@@ -255,6 +264,10 @@ class DelegatedSigningManager(BaseSendRawTransactionMixin):
 
 class PrivateKeySigningManager(BaseSendRawTransactionMixin):
     def __init__(self, *args, **kwargs):
+        warnings.warn(DeprecationWarning(
+            "PrivateKeySigningManager has been deprecated and will be removed from"
+            "web3.py in subsequen releases."
+        ))
         if not is_bitcoin_available():
             raise ImportError(
                 "In order to use the `PrivateKeySigningManager` the "


### PR DESCRIPTION
Fixes #170 

### What was wrong?

Pinning of pyrlp at `<0.4.7` is causing problems.

### How was it fixed?

Removed the pinning.

In addition went ahead and deprecated the `DelegatedSigningManager` and `PrivateKeySigning` manager classes.  They are poorly supported/tested/written and should really be done as their own package.

#### Cute Animal Picture

![75445532e51cca3acfc32541dbced407](https://cloud.githubusercontent.com/assets/824194/24204676/d86ff794-0ede-11e7-921e-9bcf02c2ec1a.jpeg)
