### PR TITLE
fix eth_sign and some parts of test_eth_sign

### DIFF
--- a/web3/eth.py
+++ b/web3/eth.py
@@ -255,11 +255,8 @@ class Eth(object):
 
     @coerce_return_to_text
     def sign(self, account, data):
-        data_hash = self.web3._requestManager.request_blocking(
-            "web3_sha3", [encode_hex(data)],
-        )
         return self.web3._requestManager.request_blocking(
-            "eth_sign", [account, data_hash],
+            "eth_sign", [account, encode_hex(data)],
         )
 
     def call(self, transaction, block_identifier=None):


### PR DESCRIPTION
### What was wrong?

the `eth_sign` method hashes the data before sending it to web3, this was wrong
the `extract_ecdsa_signer` function assumes that the value `v` of the ECDSA Signature is beween 0 and 1 but this is not the case when unsing `web3.eth.sign(...)`. 
To check a signature from `eth_sign` a prefix must be added
 `test_eth_sign` method

### How was it fixed?
update `eth_sign`
add a check and in the case update the value of `v`
adding a methods which adds the `eth.sign(...)` prefix to the message

