### PR TITLE
[Issue #194] added validation of contract `abi` param

### DIFF
--- a/tests/contracts/test_legacy_constructor_adapter.py
+++ b/tests/contracts/test_legacy_constructor_adapter.py
@@ -19,6 +19,9 @@ ABI = [
 
 ADDRESS = '0x0000000000000000000000000000000000000000'
 
+MALFORMED_ABI_1 = "NON-LIST ABI"
+MALFORMED_ABI_2 = [5, {"test": "value"}, True]
+
 
 class ContactClassForTest(Contract):
     web3 = True
@@ -47,6 +50,8 @@ class ContactClassForTest(Contract):
         ((ABI, ADDRESS), {'abi': ABI}, TypeError),
         ((ABI, ADDRESS), {'address': ADDRESS}, TypeError),
         ((ADDRESS,), {}, {'address': ADDRESS}),
+        ((), {'abi': MALFORMED_ABI_1, 'address': ADDRESS}, TypeError),
+        ((), {'abi': MALFORMED_ABI_2, 'address': ADDRESS}, TypeError),
     )
 )
 def test_process_legacy_constructor_signature(args, kwargs, expected):

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -16,6 +16,7 @@ from eth_utils import (
     coerce_return_to_text,
     force_obj_to_bytes,
     is_list_like,
+    is_dict,
 )
 
 from eth_abi import (
@@ -162,6 +163,14 @@ class Contract(object):
             if source:
                 raise TypeError("The 'source' argument was found twice")
             source = arg_4
+
+        if abi is not empty:
+            if not is_list_like(abi):
+                raise TypeError("The 'abi' argument is not a list")
+            for e in abi:
+                if not is_dict(e):
+                    raise TypeError("The elements of 'abi' argument are not all dictionaries")
+
 
         if any((abi, code, code_runtime, source)):
             warnings.warn(DeprecationWarning(

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -171,7 +171,6 @@ class Contract(object):
                 if not is_dict(e):
                     raise TypeError("The elements of 'abi' argument are not all dictionaries")
 
-
         if any((abi, code, code_runtime, source)):
             warnings.warn(DeprecationWarning(
                 "The arguments abi, code, code_runtime, and source have been "


### PR DESCRIPTION
### What was wrong?
`abi` param in `web3.eth.contract` needed validations as per [Issue #194](https://github.com/pipermerriam/web3.py/issues/194)


### How was it fixed?
Added validations to `web3.eth.contract`
Added tests cases to `contracts/test_legacy_constructor_adapter.test_process_legacy_constructor_signature`


#### Cute Animal Picture

![Cute animal picture](http://4.bp.blogspot.com/-TfrS_k9iQ3A/Tx6ksf3bOuI/AAAAAAAAA0k/9Ms3CjKgKo0/s1600/2-cute-animal-hugs-4-6-7-8-9-3-2-5-4-2-3-7-5-4-1.png)
