### PR TITLE
Transaction equality, hashing, and attributes

### DIFF
--- a/tests/utilities/test_formatter.py
+++ b/tests/utilities/test_formatter.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
-from web3 import formatters
+from web3 import formatters, transaction
 
 
 @pytest.mark.parametrize(
@@ -299,6 +299,7 @@ def test_outputPostFormatter(value, expected):
     "value,expected",
     [
         ({
+                "hash": '0x02f9c9b9cdc2092a9d6589d96662b1fd6949611163fb3910cf8a173cd060f177',
                 "input": '0x3454645634534',
                 "from": '0x00000',
                 "to": '0x00000',
@@ -310,6 +311,7 @@ def test_outputPostFormatter(value, expected):
                 "blockNumber": '0x3e8',
                 "blockHash": '0xc9b9cdc2092a9d6589d96662b1fd6949611163fb3910cf8a173cd060f17702f9'
             }, {
+                "hash": '0x02f9c9b9cdc2092a9d6589d96662b1fd6949611163fb3910cf8a173cd060f177',
                 "input": '0x3454645634534',
                 "from": '0x00000',
                 "to": '0x00000',
@@ -324,4 +326,5 @@ def test_outputPostFormatter(value, expected):
     ]
 )
 def test_output_transaction_formatter(value, expected):
-    assert formatters.output_transaction_formatter(value) == expected
+    assert formatters.output_transaction_formatter(value) == transaction.Transaction(expected)
+    assert formatters.output_transaction_formatter(value).todict() == expected

--- a/tests/utilities/test_transactions.py
+++ b/tests/utilities/test_transactions.py
@@ -1,0 +1,40 @@
+
+import pytest
+
+from web3.transaction import Transaction
+
+
+def test_same_transaction_equality():
+    t1 = Transaction({'hash': '0x1234'})
+    t2 = Transaction({'hash': '0x1234'})
+    assert t1 == t2, "different instances with the same hash should be equal"
+    assert not (t1 != t2), "different instances with the same hash should be equal"
+
+
+def test_different_transaction_inequality():
+    t1 = Transaction({'hash': '0x1234'})
+    t2 = Transaction({'hash': '0x4321'})
+    assert t1 != t2, "different instances with different hashes should be unequal"
+    assert not (t1 == t2), "different instances with different hashes should be unequal"
+
+
+def test_transaction_in_set():
+    t1 = Transaction({'hash': '0x1234'})
+    t2 = Transaction({'hash': '0x1234'})
+    tx_set = set([t1, t2])
+    assert len(tx_set) == 1, "only one of two equal transactions added to a set can remain"
+
+
+def test_transaction_attr_access():
+    t = Transaction({'hash': '0x1234'})
+    assert t.hash == t['hash'], "you must be able to access transaction values by attribute"
+
+
+def test_transaction_immutability():
+    with pytest.raises(NotImplementedError):
+        t = Transaction({'hash': '0x1234'})
+        t.hash = 'something new'
+    with pytest.raises(NotImplementedError):
+        t = Transaction({'hash': '0x1234'})
+        t['hash'] = 'something new'
+

--- a/web3/formatters.py
+++ b/web3/formatters.py
@@ -22,6 +22,7 @@ from eth_utils import (
 )
 
 from web3.iban import Iban
+from web3.transaction import Transaction
 
 from web3.utils.empty import (
     empty,
@@ -140,10 +141,10 @@ def output_transaction_formatter(txn):
         'value': to_decimal,
     }
 
-    return {
+    return Transaction({
         key: formatters.get(key, noop)(value)
         for key, value in txn.items()
-    }
+    })
 
 
 @coerce_return_to_text

--- a/web3/transaction.py
+++ b/web3/transaction.py
@@ -1,0 +1,63 @@
+
+
+class Transaction:
+    IMMUTABILITY_WARNING = "Transactions are immutable, create a new one instead of modifying this"
+
+    def __init__(self, values):
+        '''
+        @param values a dictionary of transaction values
+        '''
+        self.__dict__ = values
+        try:
+            self._unique_txid()
+        except AttributeError as e:
+            assert False, "Transaction must be uniquely defined. Failed because: %s" % e
+
+    def _unique_txid(self):
+        'currently the hash works as a unique identifier, but someday maybe not'
+        return getattr(self, 'hash')
+
+    def __getitem__(self, key):
+        return getattr(self, key)
+
+    def __setitem__(self, key, val):
+        raise NotImplementedError(Transaction.IMMUTABILITY_WARNING)
+
+    def __delitem__(self, key):
+        raise NotImplementedError(Transaction.IMMUTABILITY_WARNING)
+
+    def __iter__(self):
+        return iter(self.__dict__)
+
+    def todict(self):
+        return dict(self.__dict__)
+
+    def items(self):
+        return self.__dict__.items()
+
+    def iteritems(self):
+        return self.__dict__.iteritems()
+
+    def __setattr__(self, key, val):
+        raise NotImplementedError(Transaction.IMMUTABILITY_WARNING)
+
+    def __delattr__(self, key):
+        raise NotImplementedError(Transaction.IMMUTABILITY_WARNING)
+
+    def __contains__(self, key):
+        return key in self.__dict__
+
+    def __eq__(self, other):
+        return hasattr(other, '_unique_txid') and self._unique_txid() == other._unique_txid()
+
+    def __ne__(self, other):
+        return not (self == other)
+
+    def __hash__(self):
+        return hash(self._unique_txid())
+
+    def __str__(self):
+        return "Tx:" + self._unique_txid()
+
+    def __repr__(self):
+        return "Transaction(%r)" % self.__dict__

--- a/web3/transaction.py
+++ b/web3/transaction.py
@@ -12,6 +12,7 @@ class Transaction:
             self._unique_txid()
         except AttributeError as e:
             assert False, "Transaction must be uniquely defined. Failed because: %s" % e
+        self._locked = True
 
     def _unique_txid(self):
         'currently the hash works as a unique identifier, but someday maybe not'
@@ -39,7 +40,9 @@ class Transaction:
         return self.__dict__.iteritems()
 
     def __setattr__(self, key, val):
-        raise NotImplementedError(Transaction.IMMUTABILITY_WARNING)
+        if hasattr(self, '_locked'):
+            raise NotImplementedError(Transaction.IMMUTABILITY_WARNING)
+        super().__setattr__(key, val)
 
     def __delattr__(self, key):
         raise NotImplementedError(Transaction.IMMUTABILITY_WARNING)

--- a/web3/transaction.py
+++ b/web3/transaction.py
@@ -1,6 +1,6 @@
 
 
-class Transaction:
+class Transaction(object):
     IMMUTABILITY_WARNING = "Transactions are immutable, create a new one instead of modifying this"
 
     def __init__(self, values):
@@ -42,7 +42,7 @@ class Transaction:
     def __setattr__(self, key, val):
         if hasattr(self, '_locked'):
             raise NotImplementedError(Transaction.IMMUTABILITY_WARNING)
-        super().__setattr__(key, val)
+        super(type(self), self).__setattr__(key, val)
 
     def __delattr__(self, key):
         raise NotImplementedError(Transaction.IMMUTABILITY_WARNING)


### PR DESCRIPTION
Note that this is not a final draft ready for merging, it's meant as a reference implementation for discussion.

Some key discussion points:
1. Are my goals incompatible with other project goals?
2. Is there an alternative approach that satisfies my goals? 
3. If returning a new Tx object is acceptable, are there other important implementation issues to consider that I missed?

### What was wrong?

These were some key benefits I was looking for:
* equality test using the transaction hash value (For example, in my first several use cases, I wanted: `transaction_before_block_inclusion == transaction_after_block_inclusion`)
* can be used in a set, to prevent duplicate transactions with the same hash
* can access the transaction values as attributes (It just feels more natural to use `tx.hash` than `tx['hash']`)
* transaction object should be immutable, to eliminate a whole class of bugs at very low cost

In short, I want to use transactions as a first class object.

### How was it fixed?

I updated the output formatter to return an object of a new class that acts like a dictionary for a lot of backwards compatibility (except for equality tests, since changing that was an explicit goal).

#### Cute Animal Picture

![Cute animal picture]()
