### PR TITLE
Access fields using attributes, in transactions and blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ develop-eggs
 .installed.cfg
 lib
 lib64
+venv
 
 # Installer logs
 pip-log.txt
@@ -81,6 +82,9 @@ logs
 
 # Mongo Explorer plugin:
 .idea/mongoSettings.xml
+
+# VIM temp files
+*.swp
 
 ## File-based project format:
 *.iws

--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -9,6 +9,30 @@ Eth API
 The ``web3.eth`` object exposes the following properties and methods to
 interact with the RPC APIs under the ``eth_`` namespace.
 
+Often, when a property or method returns a mapping of keys to values, it
+will return an ``AttributeDict`` which acts like a ``dict`` but you can
+access the keys as attributes and cannot modify its fields. For example,
+you can find the latest block number in these two ways:
+
+    .. code-block:: python
+
+        >>> block = web3.eth.getBlock('latest')
+        AttributeDict({
+          'hash': '0xe8ad537a261e6fff80d551d8d087ee0f2202da9b09b64d172a5f45e818eb472a',
+          'number': 4022281,
+          # ... etc ...
+        })
+        >>> block['number']
+        4022281
+        >>> block.number
+        4022281
+        >>> block.number = 4022282
+        Traceback # ... etc ...
+        TypeError: This data is immutable -- create a copy instead of modifying
+        >>> next_block = web3.utils.datastructures.AttributeDict(block, number=4022282)
+        >>> next_block.number
+        4022282
+
 
 Properties
 ----------
@@ -38,13 +62,13 @@ The following properties are available on the ``web3.eth`` namespace.
     .. code-block:: python
 
         >>> web3.eth.syncing
-        {
+        AttributeDict({
             'currentBlock': 2177557,
             'highestBlock': 2211611,
-            'knownStates': '0x0',
-            'pulledStates': '0x0',
+            'knownStates': 0,
+            'pulledStates': 0,
             'startingBlock': 2177365,
-        }
+        })
 
 
 .. py:attribute:: Eth.coinbase
@@ -184,7 +208,7 @@ The following methods are available on the ``web3.eth`` namespace.
     .. code-block:: python
 
         >>> web3.eth.getBlock(2000000)
-        {
+        AttributeDict({
             'difficulty': 49824742724615,
             'extraData': '0xe4b883e5bda9e7a59ee4bb99e9b1bc',
             'gasLimit': 4712388,
@@ -204,7 +228,7 @@ The following methods are available on the ``web3.eth`` namespace.
             'transactions': ['0xc55e2b90168af6972193c1f86fa4d7d7b31a29c156665d15b9cd48618b5177ef'],
             'transactionsRoot': '0xb31f174d27b99cdae8e746bd138a01ce60d8dd7b224f7c60845914def05ecc58',
             'uncles': [],
-        }
+        })
 
 
 .. py:method:: Eth.getBlockTransactionCount(block_identifier)
@@ -240,7 +264,7 @@ The following methods are available on the ``web3.eth`` namespace.
     .. code-block:: python
 
         >>> web3.eth.getTransaction('0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060')
-        {
+        AttributeDict({
             'blockHash': '0x4e3a3754410177e6937ef1f84bba68ea139e8d1a2258c5f85db9f1cd715a1bdd',
             'blockNumber': 46147,
             'from': '0xa1e4380a3b1f749673e270229993ee55f35663b4',
@@ -252,7 +276,7 @@ The following methods are available on the ``web3.eth`` namespace.
             'to': '0x5df9b87991262f6ba471f09758cde1c0fc1de734',
             'transactionIndex': 0,
             'value': 31337,
-        }
+        })
 
 
 .. py:method:: Eth.getTransactionFromBlock(block_identifier, transaction_index)
@@ -270,7 +294,7 @@ The following methods are available on the ``web3.eth`` namespace.
     .. code-block:: python
 
         >>> web3.eth.getTransactionFromBlock(46147, 0)
-        {
+        AttributeDict({
             'blockHash': '0x4e3a3754410177e6937ef1f84bba68ea139e8d1a2258c5f85db9f1cd715a1bdd',
             'blockNumber': 46147,
             'from': '0xa1e4380a3b1f749673e270229993ee55f35663b4',
@@ -282,9 +306,9 @@ The following methods are available on the ``web3.eth`` namespace.
             'to': '0x5df9b87991262f6ba471f09758cde1c0fc1de734',
             'transactionIndex': 0,
             'value': 31337,
-        }
+        })
         >>> web3.eth.getTransactionFromBlock('0x4e3a3754410177e6937ef1f84bba68ea139e8d1a2258c5f85db9f1cd715a1bdd', 0)
-        {
+        AttributeDict({
             'blockHash': '0x4e3a3754410177e6937ef1f84bba68ea139e8d1a2258c5f85db9f1cd715a1bdd',
             'blockNumber': 46147,
             'from': '0xa1e4380a3b1f749673e270229993ee55f35663b4',
@@ -296,7 +320,7 @@ The following methods are available on the ``web3.eth`` namespace.
             'to': '0x5df9b87991262f6ba471f09758cde1c0fc1de734',
             'transactionIndex': 0,
             'value': 31337,
-        }
+        })
 
 
 .. py:method:: Eth.getTransactionReceipt(transaction_hash)
@@ -311,7 +335,7 @@ The following methods are available on the ``web3.eth`` namespace.
         None
         # wait for it to be mined....
         >>> web3.eth.getTransactionReceipt('0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060')
-        {
+        AttributeDict({
             'blockHash': '0x4e3a3754410177e6937ef1f84bba68ea139e8d1a2258c5f85db9f1cd715a1bdd',
             'blockNumber': 46147,
             'contractAddress': None,
@@ -323,7 +347,7 @@ The following methods are available on the ``web3.eth`` namespace.
             'to': '0x5df9b87991262f6ba471f09758cde1c0fc1de734',
             'transactionHash': '0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060',
             'transactionIndex': 0,
-        }
+        })
 
 
 .. py:method:: Eth.getTransactionCount(account, block_identifier=web3.eth.defaultBlock)

--- a/tests/utilities/test_attributedict.py
+++ b/tests/utilities/test_attributedict.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from web3.utils.datastructures import (
+    AttributeDict,
+)
+
+@pytest.mark.parametrize(
+    "dict1,dict2,same_hash",
+    [
+    ({'b': 2, 'a': 1}, {'a': 1, 'b': 2}, True),
+    ({'a': 1, 'b': 2}, {'a': 1, 'b': 0}, False),
+    ]
+)
+def test_attributedict_hashable(dict1, dict2, same_hash):
+    dicts = map(AttributeDict, (dict1, dict2))
+    dicts = set(dicts)
+    assert len(dicts) == (1 if same_hash else 2)
+
+def test_attributedict_access():
+    container = AttributeDict({'a': 1})
+    assert container.a == 1
+
+def test_attributedict_repr():
+    dict1 = AttributeDict({'a': 1})
+    dict2 = eval(repr(dict1))
+    assert dict1 == dict2
+
+def test_attributedict_setitem_invalid():
+    container = AttributeDict({'a': 1})
+    with pytest.raises(TypeError):
+        container['a'] = 0
+    assert container['a'] == 1
+
+def test_attributedict_setattr_invalid():
+    container = AttributeDict({'a': 1})
+    with pytest.raises(TypeError):
+        container.a = 0
+    assert container.a == 1
+
+def test_attributedict_delitem_invalid():
+    container = AttributeDict({'a': 1})
+    with pytest.raises(TypeError):
+        del container['a']
+    assert container['a'] == 1
+
+@pytest.mark.parametrize(
+    "dict1,dict2",
+    [
+    ({'b': 2, 'a': 1}, {'a': 1, 'b': 2}),
+    ({}, {}),
+    ]
+)
+def test_attributedict_equality(dict1, dict2):
+    assert AttributeDict(dict1) == dict2
+    assert AttributeDict(dict1) == AttributeDict(dict2)
+    assert dict1 == AttributeDict(dict2)
+
+@pytest.mark.parametrize(
+    "dict1,dict2",
+    [
+    ({'a': 1, 'b': 2}, {'a': 1, 'b': 0}),
+    ({'a': 1, 'b': 2}, {'a': 1}),
+    ]
+)
+def test_attributedict_inequality(dict1, dict2):
+    assert AttributeDict(dict1) != dict2
+    assert AttributeDict(dict1) != AttributeDict(dict2)
+    assert dict1 != AttributeDict(dict2)
+

--- a/tests/utilities/test_formatter.py
+++ b/tests/utilities/test_formatter.py
@@ -215,7 +215,9 @@ def test_input_transaction_formatter(web3, value, expected):
     ]
 )
 def test_output_block_formatter(value, expected):
-    assert formatters.output_block_formatter(value) == expected
+    block = formatters.output_block_formatter(value)
+    assert block == expected
+    assert block.size == block['size']
 
 
 @pytest.mark.parametrize(
@@ -324,4 +326,30 @@ def test_outputPostFormatter(value, expected):
     ]
 )
 def test_output_transaction_formatter(value, expected):
-    assert formatters.output_transaction_formatter(value) == expected
+    transaction = formatters.output_transaction_formatter(value)
+    assert transaction == expected
+    assert transaction.gas == transaction['gas']
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ({
+                "currentBlock": '0x3d0900',
+                "highestBlock": '0x3d6113',
+                "knownStates": '0xF',
+                "pulledStates": '0x10',
+                "startingBlock": '0x30fa2',
+            }, {
+                "currentBlock": 4000000,
+                "highestBlock": 4022547,
+                "knownStates": 15,
+                "pulledStates": 16,
+                "startingBlock": 200610,
+        })
+    ]
+)
+def test_syncing_formatter(value, expected):
+    syncing = formatters.syncing_formatter(value)
+    assert syncing == expected
+    assert syncing.startingBlock == syncing['startingBlock']

--- a/web3/formatters.py
+++ b/web3/formatters.py
@@ -23,6 +23,9 @@ from eth_utils import (
 
 from web3.iban import Iban
 
+from web3.utils.datastructures import (
+    AttributeDict,
+)
 from web3.utils.empty import (
     empty,
 )
@@ -66,6 +69,15 @@ def apply_to_array(formatter_fn):
         functools.partial(map, formatter_fn),
         list,
     )
+
+
+def wrap_with(wrapper):
+    def wrap_return(fn):
+        @functools.wraps(fn)
+        def wrapped(*args, **kwargs):
+            return wrapper(fn(*args, **kwargs))
+        return wrapped
+    return wrap_return
 
 
 @coerce_args_to_text
@@ -127,9 +139,10 @@ def input_transaction_formatter(eth, txn):
     }
 
 
+@apply_if_not_null
+@wrap_with(AttributeDict)
 @coerce_args_to_text
 @coerce_return_to_text
-@apply_if_not_null
 def output_transaction_formatter(txn):
     formatters = {
         'blockNumber': apply_if_not_null(to_decimal),
@@ -146,6 +159,7 @@ def output_transaction_formatter(txn):
     }
 
 
+@wrap_with(AttributeDict)
 @coerce_return_to_text
 def output_log_formatter(log):
     """
@@ -169,9 +183,10 @@ log_array_formatter = apply_if_not_null(apply_to_array(apply_if_dict(
 )))
 
 
+@apply_if_not_null
+@wrap_with(AttributeDict)
 @coerce_args_to_text
 @coerce_return_to_text
-@apply_if_not_null
 def output_transaction_receipt_formatter(receipt):
     """
     Formats the output of a transaction receipt to its proper values
@@ -190,6 +205,7 @@ def output_transaction_receipt_formatter(receipt):
     }
 
 
+@wrap_with(AttributeDict)
 @coerce_return_to_text
 def output_block_formatter(block):
     """
@@ -288,6 +304,7 @@ def transaction_pool_inspect_formatter(value):
 
 
 @apply_if_not_null
+@wrap_with(AttributeDict)
 def syncing_formatter(value):
     if not value:
         return value

--- a/web3/utils/datastructures.py
+++ b/web3/utils/datastructures.py
@@ -28,12 +28,19 @@ class ReadableAttributeDict(Mapping):
     def __len__(self):
         return len(self.__dict__)
 
-    def __str__(self):
-        return repr(self)
-
     def __repr__(self):
-        dict_lines = ['\n\t' + repr(k) + ': ' + repr(self[k]) + ',' for k in sorted(self.__dict__)]
-        return self.__class__.__name__ + '({' + ''.join(dict_lines) + '\n})'
+        return self.__class__.__name__ + "(%r)" % self.__dict__
+
+    def _repr_pretty_(self, builder, cycle):
+        """
+        Custom pretty output for the IPython console
+        """
+        builder.text(self.__class__.__name__ + "(")
+        if cycle:
+            builder.text("<cycle>")
+        else:
+            builder.pretty(self.__dict__)
+        builder.text(")")
 
 
 class MutableAttributeDict(MutableMapping, ReadableAttributeDict):

--- a/web3/utils/datastructures.py
+++ b/web3/utils/datastructures.py
@@ -59,16 +59,11 @@ class AttributeDict(ReadableAttributeDict, Hashable):
     def __delattr__(self, key):
         raise TypeError('This data is immutable -- create a copy instead of modifying')
 
-    def _sorteditems(self):
-        return tuple(sorted(self.items()))
-
     def __hash__(self):
-        return hash(self._sorteditems())
+        return hash(tuple(sorted(self.items())))
 
     def __eq__(self, other):
-        if hasattr(other, '__dict__'):
-            return self.__dict__ == other.__dict__
-        elif isinstance(other, Mapping):
-            return other == self.__dict__
+        if isinstance(other, Mapping):
+            return self.__dict__ == dict(other)
         else:
             return False

--- a/web3/utils/datastructures.py
+++ b/web3/utils/datastructures.py
@@ -1,9 +1,9 @@
 
 from collections import (
-        Mapping,
-        MutableMapping,
-        Hashable,
-        )
+    Mapping,
+    MutableMapping,
+    Hashable,
+)
 
 # Hashable must be immutable:
 # "the implementation of hashable collections requires that a key's hash value is immutable"
@@ -11,7 +11,9 @@ from collections import (
 
 
 class ReadableAttributeDict(Mapping):
-    'the read attributes for the AttributeDict types'
+    """
+    The read attributes for the AttributeDict types
+    """
 
     def __init__(self, dictionary, *args, **kwargs):
         self.__dict__ = dict(dictionary)
@@ -44,7 +46,9 @@ class MutableAttributeDict(MutableMapping, ReadableAttributeDict):
 
 
 class AttributeDict(ReadableAttributeDict, Hashable):
-    'This provides superficial immutability, someone could hack around it'
+    """
+    This provides superficial immutability, someone could hack around it
+    """
 
     def __setattr__(self, attr, val):
         if attr == '__dict__':

--- a/web3/utils/datastructures.py
+++ b/web3/utils/datastructures.py
@@ -1,0 +1,70 @@
+
+from collections import (
+        Mapping,
+        MutableMapping,
+        Hashable,
+        )
+
+# Hashable must be immutable:
+# "the implementation of hashable collections requires that a key's hash value is immutable"
+# https://docs.python.org/3/reference/datamodel.html#object.__hash__
+
+
+class ReadableAttributeDict(Mapping):
+    'the read attributes for the AttributeDict types'
+
+    def __init__(self, dictionary, *args, **kwargs):
+        self.__dict__ = dict(dictionary)
+        self.__dict__.update(dict(*args, **kwargs))
+
+    def __getitem__(self, key):
+        return self.__dict__[key]
+
+    def __iter__(self):
+        return iter(self.__dict__)
+
+    def __len__(self):
+        return len(self.__dict__)
+
+    def __str__(self):
+        return repr(self)
+
+    def __repr__(self):
+        dict_lines = ['\n\t' + repr(k) + ': ' + repr(self[k]) + ',' for k in sorted(self.__dict__)]
+        return self.__class__.__name__ + '({' + ''.join(dict_lines) + '\n})'
+
+
+class MutableAttributeDict(MutableMapping, ReadableAttributeDict):
+
+    def __setitem__(self, key, val):
+        self.__dict__[key] = val
+
+    def __delitem__(self, key):
+        del self.__dict__[key]
+
+
+class AttributeDict(ReadableAttributeDict, Hashable):
+    'This provides superficial immutability, someone could hack around it'
+
+    def __setattr__(self, attr, val):
+        if attr == '__dict__':
+            super(AttributeDict, self).__setattr__(attr, val)
+        else:
+            raise TypeError('This data is immutable -- create a copy instead of modifying')
+
+    def __delattr__(self, key):
+        raise TypeError('This data is immutable -- create a copy instead of modifying')
+
+    def _sorteditems(self):
+        return tuple(sorted(self.items()))
+
+    def __hash__(self):
+        return hash(self._sorteditems())
+
+    def __eq__(self, other):
+        if hasattr(other, '__dict__'):
+            return self.__dict__ == other.__dict__
+        elif isinstance(other, Mapping):
+            return other == self.__dict__
+        else:
+            return False


### PR DESCRIPTION
First draft was at #201 - see there for previous commentary. Things changed enough that I wanted a fresh branch, instead of backing out the commits or using a force push.

Additional benefits:
 * Objects become hashable for use in sets
 * Immutability by default

Currently applied to these output objects:
 * Transactions
 * Transaction Receipts
 * Blocks
 * eth.syncing

Also, I added gitignore for vim swap files and the virtualenv folder name used in the setup instructions.

### What was wrong?

These were some key benefits I was looking for:
* can be used in a set, to prevent duplicate transactions with the same hash
* can access the transaction values as attributes (It just feels more natural to use `tx.hash` than `tx['hash']`)
* transaction object should be immutable, to eliminate a whole class of bugs at very low cost

In short, I want to use transactions as a first class object. At request, I extended this concept to several other objects.

### How was it fixed?

A new AttributeDict data structure is applied to the relevant output formatters. Note that `AttributeDict(None)` will raise an exception, so `@apply_if_not_null` must precede the AttributeDict wrapper.

There is also a MutableAttributeDict that is currently unused, and a base class to share implementation details.

### What was implemented contrary to feedback?

* I used the shorter name for the Immutable version, because
** it was a bit long/unwieldy
** it was the only one in current use in the project
** it mirrors the python collections naming of: Mapping / MutableMapping
* I didn't create a separate hashable variation
** A hashable, mutable class is disallowed by python spec
** I didn't see a need for a non-hashable, immutable class

#### Cute Animal Picture

![Cute animal picture](https://d2dvlr1w1gfn2q.cloudfront.net/-P7udtby6mdw/VcEvN4xhfWI/AAAAAAAKoB4/LjMPfqwIf3Ip0-fyNd6TCsqNVYgHyZ9KwCHMYBhgL/DSC_2793.JPG?imgmax=800)
