### PR TITLE
[issue 204] migrate compose function to toolz.functoolz

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ install_requires = [
     "pysha3>=0.3",
     "requests>=2.12.4",
     "rlp>=0.4.7",
+    "toolz>=0.8.2",
 ]
 
 if sys.platform == 'win32':

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -13,7 +13,6 @@ from eth_utils import (
     encode_hex,
     add_0x_prefix,
     remove_0x_prefix,
-    compose,
     force_bytes,
     coerce_return_to_text,
     force_obj_to_bytes,
@@ -27,6 +26,10 @@ from eth_abi import (
 from eth_abi.exceptions import (
     EncodingError,
     DecodingError,
+)
+
+from toolz.functoolz import (
+    compose,
 )
 
 from web3.exceptions import (
@@ -581,6 +584,7 @@ class Contract(object):
     #
     # Private Helpers
     #
+
     @classmethod
     def _find_matching_fn_abi(cls, fn_name=None, args=None, kwargs=None):
         filters = []

--- a/web3/formatters.py
+++ b/web3/formatters.py
@@ -16,9 +16,12 @@ from eth_utils import (
     add_0x_prefix,
     encode_hex,
     decode_hex,
-    compose,
     is_list_like,
     to_normalized_address,
+)
+
+from toolz.functoolz import (
+    compose,
 )
 
 from web3.iban import Iban
@@ -57,7 +60,7 @@ def apply_if_passes_test(test_fn):
     return outer_fn
 
 
-apply_if_not_null = apply_if_passes_test(compose(is_null, operator.not_))
+apply_if_not_null = apply_if_passes_test(compose(operator.not_, is_null))
 apply_if_string = apply_if_passes_test(is_string)
 apply_if_array = apply_if_passes_test(is_list_like)
 apply_if_dict = apply_if_passes_test(is_dict)
@@ -66,8 +69,8 @@ apply_if_integer = apply_if_passes_test(is_integer)
 
 def apply_to_array(formatter_fn):
     return compose(
-        functools.partial(map, formatter_fn),
         list,
+        functools.partial(map, formatter_fn),
     )
 
 

--- a/web3/main.py
+++ b/web3/main.py
@@ -10,6 +10,9 @@ from eth_utils import (
     encode_hex,
     force_text,
     coerce_return_to_text,
+)
+
+from toolz.functoolz import (
     compose,
 )
 
@@ -67,7 +70,7 @@ class Web3(object):
     # Encoding and Decoding
     toHex = staticmethod(to_hex)
     toAscii = staticmethod(decode_hex)
-    toUtf8 = staticmethod(compose(decode_hex, force_text))
+    toUtf8 = staticmethod(compose(force_text, decode_hex))
     fromAscii = staticmethod(encode_hex)
     fromUtf8 = staticmethod(encode_hex)
     toDecimal = staticmethod(to_decimal)

--- a/web3/utils/functional.py
+++ b/web3/utils/functional.py
@@ -1,6 +1,6 @@
 import functools
 
-from eth_utils import (
+from toolz.functoolz import (
     compose,
 )
 


### PR DESCRIPTION
### What was wrong?
Issue [204](https://github.com/pipermerriam/web3.py/issues/204)


### How was it fixed?
Added toolz to setup.py.
Migrated to new function at every instance of old function, reversing direction of arguments.

#### NOTE
For `apply_formatters_to_return` in functional.py -- if formatters are order specific, then this functionality has changed. All of the instances of this decorator being used in the codebase only have a single argument so it doesn't affect any current functionality.


#### Cute Animal Picture

![Cute animal picture](https://i.redditmedia.com/fxdyrY42R1rJ-vWiSZp800if5zFX1T1UgHMKQetMVhE.jpg?w=1024&s=d2611d1c9521bbec2c921f699605175a)
