### PR TITLE
Don't wrap eth.syncing in AttributeDict when False

### DIFF
--- a/tests/eth-module/test_eth_syncing.py
+++ b/tests/eth-module/test_eth_syncing.py
@@ -1,0 +1,5 @@
+
+
+def test_eth_syncing(web3):
+    syncing = web3.eth.syncing
+    assert syncing is False

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist=
 
 [flake8]
 max-line-length= 100
-exclude= tests/*
+exclude= tests/*,venv
 
 [testenv]
 usedevelop=True

--- a/web3/formatters.py
+++ b/web3/formatters.py
@@ -310,7 +310,7 @@ def transaction_pool_inspect_formatter(value):
     return transaction_pool_formatter(value, noop)
 
 
-@apply_if_not_null
+@apply_if_dict
 @wrap_with(AttributeDict)
 def syncing_formatter(value):
     if not value:


### PR DESCRIPTION
### What was wrong?

`web3.eth.syncing` was crashing when returning `False` --  see #210

### How was it fixed?

Only wrap eth.syncing with an AttributeDict when the result is a dictionary

#### Cute Animal Picture

![Cute animal picture](https://68.media.tumblr.com/2059f58e8a97b375f19c19fcc6e4bfba/tumblr_n3p2sgPs0l1se7zkbo1_500.png)
