### PR TITLE
docs: gas is estimated for method transactions

### DIFF
--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -92,6 +92,10 @@ Each Contract Factory exposes the following methods.
     argument.  Arguments can be provided as positional arguments, keyword
     arguments, or a mix of the two.
 
+    If a ``gas`` value is not provided, then the ``gas`` value for the
+    method transaction will be created using the ``web3.eth.estimateGas()``
+    method.
+
     Returns the transaction hash.
 
     .. code-block:: python


### PR DESCRIPTION
### What was wrong?

Docs didn't explicitly state what happens when gas item is missing from contract method.

### How was it fixed?

Copied gas statement from section on contract deployment into section on contract methods.

#### Cute Animal Picture

![Cute animal picture](http://cdn.inquisitr.com/wp-content/uploads/2014/09/cute-animals-video-start-your-day.jpg)
