### PR TITLE
Do not guess if a string is already hex encoded

### DIFF
--- a/tests/contracts/test_normalization_of_return_types.py
+++ b/tests/contracts/test_normalization_of_return_types.py
@@ -28,7 +28,9 @@ from web3.utils.abi import normalize_return_type
                 '0xbb9bc244d798123fde783fcc1c72d3bb8c189413',
             ],
         ),
-    )
+    ),
+    ids=['nullbyte', 'soloaddr', 'addrlist']
+
 )
 def test_normalizing_return_values(data_type, data_value, expected_value):
     actual_value = normalize_return_type(data_type, data_value)

--- a/tests/utilities/test_encoding.py
+++ b/tests/utilities/test_encoding.py
@@ -8,6 +8,7 @@ from hypothesis import (
 from web3.utils.encoding import (
     from_decimal,
     to_decimal,
+    to_hex,
 )
 
 
@@ -40,3 +41,7 @@ def test_conversion_rount_trip(value):
     intermediate_value = from_decimal(value)
     result_value = to_decimal(intermediate_value)
     assert result_value == value, "Expected: {0!r}, Result: {1!r}, Intermediate: {2!r}".format(value, result_value, intermediate_value)
+
+def test_bytes_that_start_with_0x():
+    sneaky_bytes = b'0x\xde\xad'
+    assert to_hex(sneaky_bytes) == '0x3078dead'

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist=
 
 [flake8]
 max-line-length= 100
-exclude= tests/*,venv
+exclude= tests,venv,.tox,docs,build
 
 [testenv]
 usedevelop=True

--- a/web3/utils/encoding.py
+++ b/web3/utils/encoding.py
@@ -31,12 +31,7 @@ def to_hex(value):
         return encode_hex(json.dumps(value, sort_keys=True))
 
     if is_string(value):
-        if is_prefixed(value, '-0x'):
-            return from_decimal(value)
-        elif is_0x_prefixed(value):
-            return value
-        else:
-            return encode_hex(value)
+        return encode_hex(value)
 
     if is_integer(value):
         return from_decimal(value)

--- a/web3/utils/exception_py2.py
+++ b/web3/utils/exception_py2.py
@@ -2,4 +2,4 @@ import sys
 
 
 def raise_from(my_exception, other_exception):
-    raise my_exception, None, sys.exc_info()[2]  # noqa: W602, E999
+    raise my_exception, None, sys.exc_info()[2]  # noqa: ignore=W602, E999


### PR DESCRIPTION
Also, skip flake8 tests in several unnecessary folders. This significantly sped up my local `flake8` and `tox` run.

### What was wrong?

See issue #215 

### How was it fixed?

Stop inspecting the string for a leading '0x'

#### Cute Animal Picture

![Cute animal picture](https://www.freedawn.co.uk/scientia/wp-content/uploads/2015/04/6812816009b3017a8beee10b9495f22f.jpg)
