### PR TITLE
Fallback function does not have name and it is not emitted in solc ABI

### DIFF
--- a/tests/utilities/test_abi_filter_by_abi_name.py
+++ b/tests/utilities/test_abi_filter_by_abi_name.py
@@ -1,0 +1,71 @@
+import pytest
+
+from web3.utils.abi import (
+    filter_by_name,
+)
+
+ABI_FUNC_1 = {
+    "constant": False,
+    "inputs": [],
+    "name": "func_1",
+    "outputs": [],
+    "type": "function",
+}
+ABI_CONSTRUCTOR = {
+    "constant": False,
+    "inputs": [],
+    "type": "constructor",
+}
+ABI_FALLBACK = {
+    "constant": False,
+    "type": "fallback",
+}
+ABI_FUNC_2_SIG_A = {
+    "constant": False,
+    "inputs": [
+        {"name": "a", "type": "uint256"},
+    ],
+    "name": "func_2",
+    "outputs": [],
+    "type": "function",
+}
+ABI_FUNC_2_SIG_B = {
+    "constant": False,
+    "inputs": [
+        {"name": "a", "type": "uint256"},
+        {"name": "b", "type": "uint256"},
+    ],
+    "name": "func_2",
+    "outputs": [],
+    "type": "function",
+}
+ABI_FUNC_3 = {
+    "constant": False,
+    "inputs": [],
+    "name": "func_3",
+    "outputs": [],
+    "type": "function",
+}
+
+ABI = [
+    ABI_CONSTRUCTOR,
+    ABI_FALLBACK,
+    ABI_FUNC_1,
+    ABI_FUNC_2_SIG_A,
+    ABI_FUNC_2_SIG_B,
+    ABI_FUNC_3,
+]
+
+
+@pytest.mark.parametrize(
+    'name,expected',
+    (
+        ('func_1', [ABI_FUNC_1]),
+        ('func_2', [ABI_FUNC_2_SIG_A, ABI_FUNC_2_SIG_B]),
+        ('func_3', [ABI_FUNC_3]),
+        ('does_not_exist', []),
+    )
+)
+def test_filter_by_arguments(name, expected):
+    actual_matches = filter_by_name(name, ABI)
+    assert actual_matches == expected

--- a/web3/utils/abi.py
+++ b/web3/utils/abi.py
@@ -24,7 +24,15 @@ def filter_by_type(_type, contract_abi):
 
 
 def filter_by_name(name, contract_abi):
-    return [abi for abi in contract_abi if abi['type'] not in ('fallback', 'constructor') and abi['name'] == name]
+    return [
+        abi
+        for abi
+        in contract_abi
+        if (
+            abi['type'] not in ('fallback', 'constructor') and
+            abi['name'] == name
+        )
+    ]
 
 
 def get_abi_input_types(abi):

--- a/web3/utils/abi.py
+++ b/web3/utils/abi.py
@@ -24,11 +24,14 @@ def filter_by_type(_type, contract_abi):
 
 
 def filter_by_name(name, contract_abi):
-    return [abi for abi in contract_abi if abi.get('name') == name]
+    return [abi for abi in contract_abi if abi['type'] != 'fallback' and abi['name'] == name]
 
 
 def get_abi_input_types(abi):
-    return [arg['type'] for arg in abi.get('inputs', ())]
+    if 'inputs' not in abi and abi['type'] == 'fallback':
+        return []
+    else:
+        return [arg['type'] for arg in abi['inputs']]
 
 
 def get_abi_output_types(abi):
@@ -36,7 +39,10 @@ def get_abi_output_types(abi):
 
 
 def get_abi_input_names(abi):
-    return [arg['name'] for arg in abi.get('inputs', ())]
+    if 'inputs' not in abi and abi['type'] == 'fallback':
+        return []
+    else:
+        return [arg['name'] for arg in abi['inputs']]
 
 
 def get_indexed_event_inputs(event_abi):

--- a/web3/utils/abi.py
+++ b/web3/utils/abi.py
@@ -24,7 +24,7 @@ def filter_by_type(_type, contract_abi):
 
 
 def filter_by_name(name, contract_abi):
-    return [abi for abi in contract_abi if abi['type'] != 'fallback' and abi['name'] == name]
+    return [abi for abi in contract_abi if abi['type'] not in ('fallback', 'constructor') and abi['name'] == name]
 
 
 def get_abi_input_types(abi):

--- a/web3/utils/abi.py
+++ b/web3/utils/abi.py
@@ -28,7 +28,7 @@ def filter_by_name(name, contract_abi):
 
 
 def get_abi_input_types(abi):
-    return [arg['type'] for arg in abi['inputs']]
+    return [arg['type'] for arg in abi.get('inputs', ())]
 
 
 def get_abi_output_types(abi):
@@ -36,7 +36,7 @@ def get_abi_output_types(abi):
 
 
 def get_abi_input_names(abi):
-    return [arg['name'] for arg in abi['inputs']]
+    return [arg['name'] for arg in abi.get('inputs', ())]
 
 
 def get_indexed_event_inputs(event_abi):

--- a/web3/utils/abi.py
+++ b/web3/utils/abi.py
@@ -24,7 +24,7 @@ def filter_by_type(_type, contract_abi):
 
 
 def filter_by_name(name, contract_abi):
-    return [abi for abi in contract_abi if abi['name'] == name]
+    return [abi for abi in contract_abi if abi.get('name') == name]
 
 
 def get_abi_input_types(abi):


### PR DESCRIPTION
### What was wrong?

`pastEvents()` crashed on the latest Solidity because `name` not in the ABI dict in for a fallback function. Same is for `inputs`.

Example traceback taken from a random unit test run:

    ico/tests/contracts/test_burn.py:45: 
    _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
    venv/lib/python3.5/site-packages/web3/utils/decorators.py:12: in _wrapper
        return self.method(obj, *args, **kwargs)
    venv/lib/python3.5/site-packages/web3/contract.py:384: in pastEvents
        filter_params=event_filter_params,
    venv/lib/python3.5/site-packages/web3/utils/decorators.py:12: in _wrapper
        return self.method(obj, *args, **kwargs)
    venv/lib/python3.5/site-packages/web3/contract.py:346: in on
        argument_filter_names,
    venv/lib/python3.5/site-packages/web3/contract.py:643: in _find_matching_event_abi
        event_abi_candidates = filter_fn(cls.abi)
    venv/lib/python3.5/site-packages/toolz/functoolz.py:468: in __call__
        ret = f(ret)
    venv/lib/python3.5/site-packages/web3/utils/abi.py:27: in filter_by_name
        return [abi for abi in contract_abi if abi['name'] == name]
    _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

    .0 = <list_iterator object at 0x112651dd8>

    >   return [abi for abi in contract_abi if abi['name'] == name]


### How was it fixed?

Consider name field optional.

#### Cute Animal Picture

`~~~~~`
