### PR TITLE
[Issue 213] migrate to cytoolz library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ install_requires = [
     "pysha3>=0.3",
     "requests>=2.12.4",
     "rlp>=0.4.7",
-    "toolz>=0.8.2",
+    "cytoolz>=0.8.2",
 ]
 
 if sys.platform == 'win32':

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -27,7 +27,7 @@ from eth_abi.exceptions import (
     DecodingError,
 )
 
-from toolz.functoolz import (
+from cytoolz.functoolz import (
     compose,
 )
 

--- a/web3/formatters.py
+++ b/web3/formatters.py
@@ -5,30 +5,26 @@ import functools
 import operator
 
 from eth_utils import (
+    add_0x_prefix,
     coerce_args_to_text,
     coerce_return_to_text,
-    is_address,
-    is_string,
-    is_integer,
-    is_null,
-    is_dict,
-    is_0x_prefixed,
-    add_0x_prefix,
-    encode_hex,
+    compose as _compose,
     decode_hex,
+    encode_hex,
+    is_0x_prefixed,
+    is_address,
+    is_dict,
+    is_integer,
     is_list_like,
+    is_null,
+    is_string,
     to_normalized_address,
 )
 
-'''
 from cytoolz.functoolz import (
     compose,
 )
-'''
 
-from toolz.functoolz import (
-    compose,
-)
 from web3.iban import Iban
 
 from web3.utils.datastructures import (
@@ -76,9 +72,11 @@ apply_if_integer = apply_if_passes_test(is_integer)
 
 
 def apply_to_array(formatter_fn):
-    return compose(
-        list,
+    # workaround for https://github.com/pytoolz/cytoolz/issues/103
+    # NOTE: must reverse arguments when migrating from _compose to cytoolz.compose
+    return _compose(
         functools.partial(map, formatter_fn),
+        list,
     )
 
 

--- a/web3/formatters.py
+++ b/web3/formatters.py
@@ -20,10 +20,15 @@ from eth_utils import (
     to_normalized_address,
 )
 
+'''
+from cytoolz.functoolz import (
+    compose,
+)
+'''
+
 from toolz.functoolz import (
     compose,
 )
-
 from web3.iban import Iban
 
 from web3.utils.datastructures import (

--- a/web3/main.py
+++ b/web3/main.py
@@ -12,7 +12,7 @@ from eth_utils import (
     coerce_return_to_text,
 )
 
-from toolz.functoolz import (
+from cytoolz.functoolz import (
     compose,
 )
 

--- a/web3/utils/functional.py
+++ b/web3/utils/functional.py
@@ -1,6 +1,6 @@
 import functools
 
-from toolz.functoolz import (
+from cytoolz.functoolz import (
     compose,
 )
 


### PR DESCRIPTION
### What was wrong?
[Issue 213](https://github.com/pipermerriam/web3.py/issues/213)


### How was it fixed?
Migrated to cytoolz. Checked against existing tests.

Note: one call to compose in web3/formatters.py resulted in an error related to the cytoolz codebase.  See [cytoolz issue 103](https://github.com/pytoolz/cytoolz/issues/103). Workaround in place with comment about issue and notes about resolving.


#### Cute Animal Picture

![Cute animal picture](https://img.designswan.com/2014/05/fox/2.jpg)
