### PR TITLE
bump ethereum-utils to 0.4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ readme = open(os.path.join(DIR, 'README.md')).read()
 
 install_requires = [
     "ethereum-abi-utils>=0.4.0",
-    "ethereum-utils>=0.3.0",
+    "ethereum-utils>=0.4.0",
     "pylru>=1.0.9",
     "pysha3>=0.3",
     "requests>=2.12.4",


### PR DESCRIPTION
### What was wrong?

Upstream fix for `web3.isAddress()` function to verify checksum addresses.

### How was it fixed?

Bump to `ethereum-utils>=0.4.0`

#### Cute Animal Picture

![06-baby-skunks](https://user-images.githubusercontent.com/824194/29237563-dc54b728-7f18-11e7-9460-72ff25cd0f09.jpg)
