### PR TITLE
Allow local signing of contract method transactions

### DIFF
--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -78,14 +78,16 @@ Each Contract Factory exposes the following methods.
 
 .. py:method:: Contract.transact(transaction).myMethod(*args, **kwargs)
 
-    Execute the specified function by sending a new public transaction.  
+    Execute the specified function by sending a new public transaction.
 
     This is executed in two steps.
-    
+
     The first portion of this function call ``transact(transaction)`` takes a
     single parameter which should be a python dictionary conforming to
     the same format as the ``web3.eth.sendTransaction(transaction)`` method.
-    This dictionary may not contain the keys ``data`` or ``to``.
+    This dictionary may not contain the keys ``data`` or ``to``. In addition,
+    the `private_key` entry is allowed. If specified, the transaction will be
+    be signed locally instead of on the connected node.
 
     The second portion of the function call ``myMethod(*args, **kwargs)``
     selects the appropriate contract function based on the name and provided

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ DIR = os.path.dirname(os.path.abspath(__file__))
 readme = open(os.path.join(DIR, 'README.md')).read()
 
 install_requires = [
+    "ethereum",
     "ethereum-abi-utils>=0.4.0",
     "ethereum-utils>=0.3.0",
     "pylru>=1.0.9",

--- a/tests/contracts/test_contract_transact_interface.py
+++ b/tests/contracts/test_contract_transact_interface.py
@@ -213,6 +213,12 @@ def test_transacting_with_private_key(web3, math_contract, wait_for_transaction)
     assert txn_info.value == 321
     assert txn_info.nonce == 1
 
+    # works without gas specified
+    math_contract.transact({
+        'private_key': private_key,
+        'gasPrice': 0
+    }).increment()
+
     # raise because of both `private_key` and `from`
     with pytest.raises(ValueError):
         other_sender = privtoaddr(mk_random_privkey())
@@ -220,12 +226,6 @@ def test_transacting_with_private_key(web3, math_contract, wait_for_transaction)
             'private_key': private_key,
             'from': other_sender,
             'gas': 20000,
-            'gasPrice': 0
-        })
-    # raise because of no `gas`
-    with pytest.raises(ValueError):
-        math_contract.transact({
-            'private_key': private_key,
             'gasPrice': 0
         })
     # raise because of no `gasPrice`

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -575,8 +575,6 @@ class Contract(object):
         if 'private_key' in transact_transaction:
             if 'from' in transact_transaction:
                 raise ValueError('Cannot set both `from` and `private_key`')
-            if 'gas' not in transact_transaction:
-                raise ValueError('If `private_key` is specified, `gas` must be as well')
             if 'gasPrice' not in transact_transaction:
                 raise ValueError('If `private_key` is specified, `gasPrice` must be as well')
             sender = privtoaddr(transact_transaction['private_key'])
@@ -861,6 +859,11 @@ def transact_with_contract_function(contract=None,
             sender = transact_transaction['from']
             nonce = contract.web3.eth.getTransactionCount(sender)
             transact_transaction['nonce'] = nonce
+        if 'gas' not in transact_transaction:
+            gas_estimation_transaction = {k: v for k, v in transact_transaction.items()
+                                          if k not in ('private_key', 'nonce')}
+            gas = contract.web3.eth.estimateGas(gas_estimation_transaction)
+            transact_transaction['gas'] = gas
         tx = Transaction(
             transact_transaction['nonce'],
             transact_transaction['gasPrice'],


### PR DESCRIPTION
### What was wrong?

It was not possible to send transactions calling contract methods if the RPC client doesn't have access to the private key (e.g., Infura).


### How was it fixed?

Add the option to pass a private key to `contract.transact`. If a key is given, the transaction is created locally, signed with the key and sent with `eth_sendRawTransaction`.

For this, I had to add pyethereum to the dependencies. If it is too heavy we could also make it optional.


#### Cute Animal Picture

![Cute animal picture](https://i.imgur.com/4nlgwoc.jpg)
