### PR TITLE
Piper/module api

### DIFF
--- a/web3/admin.py
+++ b/web3/admin.py
@@ -1,7 +1,9 @@
-class Admin(object):
-    def __init__(self, web3):
-        self.web3 = web3
+from web3.utils.module import (
+    Module,
+)
 
+
+class Admin(Module):
     def addPeer(self, node_url):
         return self.web3._requestManager.request_blocking(
             "admin_addPeer", [node_url],

--- a/web3/db.py
+++ b/web3/db.py
@@ -1,7 +1,9 @@
-class Db(object):
-    def __init__(self, web3):
-        self.web3 = web3
+from web3.utils.module import (
+    Module,
+)
 
+
+class Db(Module):
     def putString(self, *args, **kwargs):
         raise DeprecationWarning("This function has been deprecated")
 

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -19,19 +19,13 @@ from web3.utils.blocks import (
 from web3.utils.empty import (
     empty,
 )
-from web3.utils.encoding import (
-    to_decimal,
-)
 from web3.utils.filters import (
     BlockFilter,
     TransactionFilter,
     LogFilter,
 )
-from web3.utils.functional import (
-    apply_formatters_to_return,
-)
-from web3.utils.transactions import (
-    get_buffered_gas_estimate,
+from web3.utils.module import (
+    Module,
 )
 from web3.utils.validation import (
     validate_address,
@@ -39,12 +33,8 @@ from web3.utils.validation import (
 )
 
 
-class Eth(object):
-    def __init__(self, web3):
-        self.web3 = web3
-        self.iban = Iban
-        # self.sendIBANTransaction = lambda: raise NotImplementedError()
-
+class Eth(Module):
+    iban = Iban
     defaultAccount = empty
     defaultBlock = "latest"
 

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -19,13 +19,22 @@ from web3.utils.blocks import (
 from web3.utils.empty import (
     empty,
 )
+from web3.utils.encoding import (
+    to_decimal,
+)
 from web3.utils.filters import (
     BlockFilter,
     TransactionFilter,
     LogFilter,
 )
+from web3.utils.functional import (
+    apply_formatters_to_return,
+)
 from web3.utils.module import (
     Module,
+)
+from web3.utils.transactions import (
+    get_buffered_gas_estimate,
 )
 from web3.utils.validation import (
     validate_address,

--- a/web3/main.py
+++ b/web3/main.py
@@ -52,6 +52,21 @@ from web3.utils.encoding import (
 )
 
 
+def get_default_modules():
+    return {
+        "eth": Eth,
+        "db": Db,
+        "shh": Shh,
+        "net": Net,
+        "personal": Personal,
+        "version": Version,
+        "txpool": TxPool,
+        "miner": Miner,
+        "admin": Admin,
+        "testing": Testing,
+    }
+
+
 class Web3(object):
     # Providers
     HTTPProvider = HTTPProvider
@@ -85,19 +100,27 @@ class Web3(object):
     isChecksumAddress = staticmethod(is_checksum_address)
     toChecksumAddress = staticmethod(to_checksum_address)
 
-    def __init__(self, provider):
-        self._requestManager = RequestManager(provider)
+    def __init__(self, provider, modules=None):
+        self.manager = RequestManager(provider)
 
-        self.eth = Eth(self)
-        self.db = Db(self)
-        self.shh = Shh(self)
-        self.net = Net(self)
-        self.personal = Personal(self)
-        self.version = Version(self)
-        self.txpool = TxPool(self)
-        self.miner = Miner(self)
-        self.admin = Admin(self)
-        self.testing = Testing(self)
+        if modules is None:
+            modules = get_default_modules()
+
+        for module_name, module_class in modules.items():
+            if hasattr(self, module_name):
+                raise AttributeError(
+                    "Cannot set web3 module named '{0}'.  The web3 object "
+                    "already has an attribute with that name".format(module_name)
+                )
+            setattr(self, module_name, module_class(self))
+
+    @property
+    def provider(self):
+        return self.manager.provider
+
+    @provider.setter
+    def provider(self, value):
+        self.manager.provider = value
 
     def setProvider(self, provider):
         self._requestManager.setProvider(provider)

--- a/web3/main.py
+++ b/web3/main.py
@@ -101,7 +101,7 @@ class Web3(object):
     toChecksumAddress = staticmethod(to_checksum_address)
 
     def __init__(self, provider, modules=None):
-        self.manager = RequestManager(provider)
+        self._requestManager = RequestManager(provider)
 
         if modules is None:
             modules = get_default_modules()
@@ -113,14 +113,6 @@ class Web3(object):
                     "already has an attribute with that name".format(module_name)
                 )
             setattr(self, module_name, module_class(self))
-
-    @property
-    def provider(self):
-        return self.manager.provider
-
-    @provider.setter
-    def provider(self, value):
-        self.manager.provider = value
 
     def setProvider(self, provider):
         self._requestManager.setProvider(provider)

--- a/web3/miner.py
+++ b/web3/miner.py
@@ -1,10 +1,12 @@
-from web3.utils.functional import (
-    apply_formatters_to_return,
-)
 from web3.utils.encoding import (
     to_decimal,
 )
-
+from web3.utils.functional import (
+    apply_formatters_to_return,
+)
+from web3.utils.module import (
+    Module,
+)
 
 
 class Miner(Module):

--- a/web3/miner.py
+++ b/web3/miner.py
@@ -6,10 +6,8 @@ from web3.utils.encoding import (
 )
 
 
-class Miner(object):
-    def __init__(self, web3):
-        self.web3 = web3
 
+class Miner(Module):
     @property
     @apply_formatters_to_return(to_decimal)
     def hashrate(self):

--- a/web3/net.py
+++ b/web3/net.py
@@ -4,9 +4,9 @@ from web3.utils.encoding import (
 from web3.utils.functional import (
     apply_formatters_to_return,
 )
-
-
-class Net(object):
+from web3.utils.module import (
+    Module,
+)
 
 
 class Net(Module):

--- a/web3/net.py
+++ b/web3/net.py
@@ -8,9 +8,8 @@ from web3.utils.functional import (
 
 class Net(object):
 
-    def __init__(self, web3):
-        self.web3 = web3
 
+class Net(Module):
     @property
     def listening(self):
         return self.web3._requestManager.request_blocking("net_listening", [])

--- a/web3/personal.py
+++ b/web3/personal.py
@@ -1,6 +1,11 @@
 from __future__ import absolute_import
 
 import getpass
+import warnings
+
+from web3.utils.module import (
+    Module,
+)
 
 from eth_utils import (
     coerce_return_to_text,
@@ -9,13 +14,10 @@ from eth_utils import (
 )
 
 
-class Personal(object):
+class Personal(Module):
     """
     https://github.com/ethereum/go-ethereum/wiki/Management-APIs#personal
     """
-    def __init__(self, web3):
-        self.web3 = web3
-
     @coerce_return_to_text
     def importRawKey(self, private_key, passphrase):
         if len(private_key) == 66:

--- a/web3/personal.py
+++ b/web3/personal.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 import getpass
-import warnings
 
 from web3.utils.module import (
     Module,

--- a/web3/shh.py
+++ b/web3/shh.py
@@ -8,19 +8,12 @@ from web3.utils.functional import (
 from web3.utils.filters import (
     ShhFilter,
 )
+from web3.utils.module import (
+    Module,
+)
 
 
-class Shh(object):
-    """
-    TODO: flesh this out.
-    """
-    def __init__(self, web3):
-        self.web3 = web3
-
-    @property
-    def request_manager(self):
-        return self.web3._requestManager
-
+class Shh(Module):
     @property
     @apply_formatters_to_return(to_decimal)
     def version(self):

--- a/web3/testing.py
+++ b/web3/testing.py
@@ -4,7 +4,9 @@ from web3.utils.encoding import (
 from web3.utils.functional import (
     apply_formatters_to_return,
 )
-
+from web3.utils.module import (
+    Module,
+)
 
 
 class Testing(Module):

--- a/web3/testing.py
+++ b/web3/testing.py
@@ -6,10 +6,8 @@ from web3.utils.functional import (
 )
 
 
-class Testing(object):
-    def __init__(self, web3):
-        self.web3 = web3
 
+class Testing(Module):
     def timeTravel(self, timestamp):
         return self.web3._requestManager.request_blocking("testing_timeTravel", [timestamp])
 

--- a/web3/txpool.py
+++ b/web3/txpool.py
@@ -7,10 +7,8 @@ from web3.formatters import (
 )
 
 
-class TxPool(object):
-    def __init__(self, web3):
-        self.web3 = web3
 
+class TxPool(Module):
     @property
     @apply_formatters_to_return(transaction_pool_content_formatter)
     def content(self):

--- a/web3/txpool.py
+++ b/web3/txpool.py
@@ -1,11 +1,14 @@
-from web3.utils.functional import (
-    apply_formatters_to_return,
-)
 from web3.formatters import (
     transaction_pool_content_formatter,
     transaction_pool_inspect_formatter,
 )
 
+from web3.utils.functional import (
+    apply_formatters_to_return,
+)
+from web3.utils.module import (
+    Module,
+)
 
 
 class TxPool(Module):

--- a/web3/utils/module.py
+++ b/web3/utils/module.py
@@ -1,0 +1,5 @@
+class Module(object):
+    web3 = None
+
+    def __init__(self, web3):
+        self.web3 = web3

--- a/web3/version.py
+++ b/web3/version.py
@@ -8,10 +8,8 @@ from web3.utils.functional import (
 )
 
 
-class Version(object):
-    def __init__(self, web3):
-        self.web3 = web3
 
+class Version(Module):
     @property
     def api(self):
         from web3 import __version__

--- a/web3/version.py
+++ b/web3/version.py
@@ -6,7 +6,9 @@ from web3.utils.encoding import (
 from web3.utils.functional import (
     apply_formatters_to_return,
 )
-
+from web3.utils.module import (
+    Module,
+)
 
 
 class Version(Module):


### PR DESCRIPTION
### What was wrong?

Ended up implementing a base `Module` object for all of the various web3 modules while working on the Middleware API.  This didn't need to go with those changes and could be merged on its own.

### How was it fixed?

Extracted it into a stand-alone pull request.

#### Cute Animal Picture

![896b2c322f2aab6b6d3a24e195bb333c](https://user-images.githubusercontent.com/824194/29444016-6642adb2-8399-11e7-8512-5c8ef7b1ebcf.jpg)
