### PR TITLE
Raise error specific to address checksum failure

### DIFF
--- a/web3/utils/validation.py
+++ b/web3/utils/validation.py
@@ -22,9 +22,9 @@ def validate_address(value):
     """
     Helper function for validating an address
     """
+    validate_address_checksum(value)
     if not is_address(value):
         raise ValueError("'{0}' is not an address".format(value))
-    validate_address_checksum(value)
 
 
 def validate_address_checksum(value):


### PR DESCRIPTION
@djrtwo Can you confirm this is what you were intending with the address validation?

### What was wrong?

Addresses that are correctly formatted, but have an invalid checksum, would cause a generic "not an address" failure.

### How was it fixed?

Move the custom checksum check before the more general "is this an address" check.

#### Cute Animal Picture

![Cute animal picture](https://hdwallsource.com/img/2014/2/cute-baby-tiger-30499-31220-hd-wallpapers.jpg)
