### PR TITLE
Piper/middleware api tweaks

### DIFF
--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -143,7 +143,7 @@ business logic for web3 requests.  Writing middleware is simple.
     def simple_middleware(make_request, web3):
         # do one-time setup operations here
 
-        def middleware(method, params, request_id):
+        def middleware(method, params):
             # do pre-processing here
 
             # perform the RPC request, getting the response
@@ -166,7 +166,7 @@ It is also possible to implement middlewares as a class.
             self.web3 = web3
             self.make_request = make_request
 
-        def __call__(self, method, params, request_id):
+        def __call__(self, method, params):
             # do pre-processing here
 
             # perform the RPC request, getting the response

--- a/tests/manager/test_middleware_add_and_clear_api.py
+++ b/tests/manager/test_middleware_add_and_clear_api.py
@@ -45,3 +45,23 @@ def test_provider_property_setter_and_getter():
         middleware_a,
         middleware_b,
     )
+
+
+def test_modifying_middleware_regenerates_request_functions():
+    provider = BaseProvider()
+
+    manager = RequestManager(None, provider, middlewares=[])
+
+    id_a = id(manager._wrapped_provider_request_functions)
+
+    manager.add_middleware(middleware_factory())
+
+    id_b = id(manager._wrapped_provider_request_functions)
+
+    assert id_b != id_a
+
+    manager.clear_middlewares()
+
+    id_c = id(manager._wrapped_provider_request_functions)
+
+    assert id_b != id_c

--- a/tests/manager/test_middleware_add_and_clear_api.py
+++ b/tests/manager/test_middleware_add_and_clear_api.py
@@ -1,0 +1,47 @@
+from web3.manager import (
+    RequestManager,
+)
+from web3.providers import (
+    BaseProvider,
+)
+
+
+def middleware_factory():
+    def generated_middleware(*args, **kwargs):
+        def middleware(*args, **kwargs):
+            pass
+        return middleware
+    return generated_middleware
+
+
+def test_provider_property_setter_and_getter():
+    provider = BaseProvider()
+
+    middleware_a = middleware_factory()
+    middleware_b = middleware_factory()
+    assert middleware_a is not middleware_b
+
+    manager = RequestManager(None, provider, middlewares=[])
+
+    assert manager.middlewares == tuple()
+
+    manager.add_middleware(middleware_a)
+    manager.add_middleware(middleware_b)
+
+    manager.clear_middlewares()
+
+    assert manager.middlewares == tuple()
+
+    manager.add_middleware(middleware_b)
+    manager.add_middleware(middleware_a)
+    manager.add_middleware(middleware_b)
+    manager.add_middleware(middleware_b)
+    manager.add_middleware(middleware_a)
+
+    assert manager.middlewares == (
+        middleware_a,
+        middleware_b,
+        middleware_b,
+        middleware_a,
+        middleware_b,
+    )

--- a/tests/manager/test_middleware_can_be_stateful.py
+++ b/tests/manager/test_middleware_can_be_stateful.py
@@ -1,0 +1,30 @@
+from web3.manager import (
+    RequestManager,
+)
+from web3.providers import (
+    BaseProvider,
+)
+
+
+def stateful_middleware(make_request, web3):
+    state = []
+
+    def middleware(method, params):
+        state.append((method, params))
+        return {'result': state}
+
+    middleware.state = state
+    return middleware
+
+
+def test_middleware_holds_state_across_requests():
+    provider = BaseProvider()
+
+    manager = RequestManager(None, provider, middlewares=[stateful_middleware])
+    state_a = manager.request_blocking('test_statefulness', [])
+    assert len(state_a) == 1
+
+    state_b = manager.request_blocking('test_statefulness', [])
+
+    assert id(state_a) == id(state_b)
+    assert len(state_b) == 2

--- a/tests/manager/test_provider_property.py
+++ b/tests/manager/test_provider_property.py
@@ -18,3 +18,17 @@ def test_provider_property_setter_and_getter():
     manager.providers = provider_b
 
     assert manager.providers[0] is provider_b
+
+
+def test_provider_property_triggers_regeneration_of_wrapped_middleware():
+    provider = BaseProvider()
+
+    manager = RequestManager(None, provider)
+
+    prev_id = id(manager._wrapped_provider_request_functions)
+
+    manager.providers = provider
+
+    after_id = id(manager._wrapped_provider_request_functions)
+
+    assert prev_id != after_id

--- a/tests/manager/test_provider_request_wrapping.py
+++ b/tests/manager/test_provider_request_wrapping.py
@@ -8,7 +8,7 @@ from web3.providers import (
 
 def middleware_factory(key):
     def middleware_wrapper(make_request, web3):
-        def middleware_fn(method, params, request_id):
+        def middleware_fn(method, params):
             params.append(key)
             method = "|".join((method, key))
             response = make_request(method, params)
@@ -37,7 +37,7 @@ def test_provider_property_setter_and_getter():
     provider = DummyProvider()
 
     manager = RequestManager(None, provider, middlewares=[middleware_a, middleware_b])
-    response = manager.request_blocking('init', ['init'], 'id-12345')
+    response = manager.request_blocking('init', ['init'])
 
     assert response['method'] == 'init|middleware-A|middleware-B'
     assert response['params'] == ['init', 'middleware-A', 'middleware-B']

--- a/web3/main.py
+++ b/web3/main.py
@@ -116,6 +116,18 @@ class Web3(object):
                 )
             setattr(self, module_name, module_class(self))
 
+    def add_middleware(self, middleware):
+        """
+        Convenience API for RequestManager.add_middleware
+        """
+        self.manager.add_middleware(middleware)
+
+    def clear_middlewares(self):
+        """
+        Convenience API for RequestManager.clear_middlewares
+        """
+        self.manager.clear_middlewares()
+
     @property
     def providers(self):
         return self.manager.providers

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -1,3 +1,4 @@
+import itertools
 import uuid
 import warnings
 
@@ -10,8 +11,9 @@ from web3.exceptions import (
     UnhandledRequest,
 )
 from web3.middleware import (
-    wrap_provider_request,
+    combine_middlewares,
     pythonic_middleware,
+    attrdict_middlware,
 )
 
 from web3.utils.compat import (
@@ -23,20 +25,49 @@ class RequestManager(object):
     def __init__(self, web3, providers, middlewares=None):
         self.web3 = web3
         self.pending_requests = {}
-        self.providers = providers
 
         if middlewares is None:
-            middlewares = [pythonic_middleware]
+            middlewares = [attrdict_middlware, pythonic_middleware]
 
         self.middlewares = middlewares
+        self.providers = providers
 
     web3 = None
-    middlewares = None
-    _provider = None
+    _middlewares = None
+    _providers = None
+
+    @property
+    def middlewares(self):
+        return self._middlewares or tuple()
+
+    @middlewares.setter
+    def middlewares(self, value):
+        self._middlewares = tuple(value)
+        self._generate_request_functions()
+
+    def _generate_request_functions(self):
+        self._combined_middlewares = {
+            index: combine_middlewares(
+                middlewares=self._middlewares,
+                web3=self.web3,
+                provider_request_fn=provider.make_request,
+            )
+            for index, provider
+            in enumerate(self.providers)
+        }
+
+    def add_middleware(self, middleware):
+        self.middlewares = tuple(itertools.chain(
+            [middleware],
+            self.middlewares,
+        ))
+
+    def clear_middlewares(self):
+        self.middlewares = tuple()
 
     @property
     def providers(self):
-        return self._provider
+        return self._providers or tuple()
 
     @providers.setter
     def providers(self, value):
@@ -44,7 +75,8 @@ class RequestManager(object):
             providers = [value]
         else:
             providers = value
-        self._provider = providers
+        self._providers = providers
+        self._generate_request_functions()
 
     def setProvider(self, providers):
         warnings.warn(DeprecationWarning(
@@ -56,41 +88,28 @@ class RequestManager(object):
     #
     # Provider requests and response
     #
-    def _get_request_id(self):
-        request_id = uuid.uuid4()
-        return request_id
-
-    def _make_request(self, method, params, request_id):
-        for provider in self.providers:
+    def _make_request(self, method, params):
+        for index in range(len(self.providers)):
+            make_request_fn = self._combined_middlewares[index]
             try:
-                return wrap_provider_request(
-                    middlewares=self.middlewares,
-                    web3=self.web3,
-                    make_request_fn=provider.make_request,
-                    request_id=request_id,
-                )(method, params)
+                return make_request_fn(method, params)
             except CannotHandleRequest:
                 continue
         else:
             raise UnhandledRequest(
                 "No providers responded to the RPC request:\n"
                 "method:{0}\n"
-                "params:{1}\n"
-                "request_id: {2}".format(
+                "params:{1}\n".format(
                     method,
                     params,
-                    request_id
                 )
             )
 
-    def request_blocking(self, method, params, request_id=None):
+    def request_blocking(self, method, params):
         """
         Make a synchronous request using the provider
         """
-        if request_id is None:
-            request_id = self._get_request_id()
-
-        response = self._make_request(method, params, request_id)
+        response = self._make_request(method, params)
 
         if "error" in response:
             raise ValueError(response["error"])
@@ -98,12 +117,11 @@ class RequestManager(object):
         return response['result']
 
     def request_async(self, raw_method, raw_params):
-        request_id = self._get_request_id()
+        request_id = uuid.uuid4()
         self.pending_requests[request_id] = spawn(
             self.request_blocking,
             raw_method=raw_method,
             raw_params=raw_params,
-            request_id=request_id,
         )
         return request_id
 

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -46,7 +46,7 @@ class RequestManager(object):
         self._generate_request_functions()
 
     def _generate_request_functions(self):
-        self._combined_middlewares = {
+        self._wrapped_provider_request_functions = {
             index: combine_middlewares(
                 middlewares=self._middlewares,
                 web3=self.web3,
@@ -90,7 +90,7 @@ class RequestManager(object):
     #
     def _make_request(self, method, params):
         for index in range(len(self.providers)):
-            make_request_fn = self._combined_middlewares[index]
+            make_request_fn = self._wrapped_provider_request_functions[index]
             try:
                 return make_request_fn(method, params)
             except CannotHandleRequest:

--- a/web3/middleware/__init__.py
+++ b/web3/middleware/__init__.py
@@ -1,37 +1,24 @@
 from __future__ import absolute_import
 import functools
 
-from cytoolz.functoolz import (
-    partial,
-    curry,
-)
-
 from .formatting import (  # noqa: F401
     construct_formatting_middleware,
 )
 from .pythonic import (  # noqa: F401
     pythonic_middleware,
 )
+from .attrdict import (  # noqa: F401
+    attrdict_middlware,
+)
 
 
-@curry
-def _reduce_middleware_fn(request_fn, middleware, web3, request_id):
+def combine_middlewares(middlewares, web3, provider_request_fn):
     """
-    The reduce function for wrapping the provider request in the middlewares.
-    """
-    return partial(
-        middleware(request_fn, web3),
-        request_id=request_id,
-    )
-
-
-def wrap_provider_request(middlewares, web3, make_request_fn, request_id):
-    """
-    Returns a callable function which will call the provider.make_request
+    Returns a callable function which will call the provider.provider_request
     function wrapped with all of the middlewares.
     """
     return functools.reduce(
-        _reduce_middleware_fn(web3=web3, request_id=request_id),
+        lambda request_fn, middleware: middleware(request_fn, web3),
         reversed(middlewares),
-        make_request_fn,
+        provider_request_fn,
     )

--- a/web3/middleware/attrdict.py
+++ b/web3/middleware/attrdict.py
@@ -1,0 +1,30 @@
+from cytoolz.dicttoolz import (
+    assoc,
+)
+
+from eth_utils import (
+    is_dict,
+)
+
+
+from web3.utils.datastructures import (
+    AttributeDict,
+)
+
+
+def attrdict_middlware(make_request, web3):
+    """
+    Converts any result which is a dictionary into an a
+    """
+    def middleware(method, params):
+        response = make_request(method, params)
+
+        if 'result' in response:
+            result = response['result']
+            if is_dict(result) and not isinstance(result, AttributeDict):
+                return assoc(response, 'result', AttributeDict(result))
+            else:
+                return response
+        else:
+            return response
+    return middleware

--- a/web3/middleware/formatting.py
+++ b/web3/middleware/formatting.py
@@ -16,7 +16,7 @@ def construct_formatting_middleware(request_formatters=None,
         error_formatters = {}
 
     def formatter_middleware(make_request, web3):
-        def middleware(method, params, request_id):
+        def middleware(method, params):
             if method in request_formatters:
                 formatter = request_formatters[method]
                 formatted_params = formatter(params)


### PR DESCRIPTION
### What was wrong?

The middleware API needed some tweaks.

### How was it fixed?

* Removed the `request_id` from the API as it was no longer needed.
* Middleware can now be stateful as they are only instantiated once.
* Added `AttributeDict` wrapping middleware.

#### Cute Animal Picture

![baby lion wallpaper](https://user-images.githubusercontent.com/824194/29647369-17f690a4-8846-11e7-8fa9-2da8614a4c20.jpg)

