### PR TITLE
fix type in attrdict middleware name

### DIFF
--- a/web3/manager.py
+++ b/web3/manager.py
@@ -13,7 +13,7 @@ from web3.exceptions import (
 from web3.middleware import (
     combine_middlewares,
     pythonic_middleware,
-    attrdict_middlware,
+    attrdict_middleware,
 )
 
 from web3.utils.compat import (
@@ -27,7 +27,7 @@ class RequestManager(object):
         self.pending_requests = {}
 
         if middlewares is None:
-            middlewares = [attrdict_middlware, pythonic_middleware]
+            middlewares = [attrdict_middleware, pythonic_middleware]
 
         self.middlewares = middlewares
         self.providers = providers

--- a/web3/middleware/__init__.py
+++ b/web3/middleware/__init__.py
@@ -8,7 +8,7 @@ from .pythonic import (  # noqa: F401
     pythonic_middleware,
 )
 from .attrdict import (  # noqa: F401
-    attrdict_middlware,
+    attrdict_middleware,
 )
 
 

--- a/web3/middleware/attrdict.py
+++ b/web3/middleware/attrdict.py
@@ -12,7 +12,7 @@ from web3.utils.datastructures import (
 )
 
 
-def attrdict_middlware(make_request, web3):
+def attrdict_middleware(make_request, web3):
     """
     Converts any result which is a dictionary into an a
     """


### PR DESCRIPTION
### What was wrong?

I mispelled the `attrdict_middlware` as `attrdict_middlware`.

### How was it fixed?

Fixed it

#### Cute Animal Picture

![leaf-footed bug eggs probably acanthocephala terminalis 1](https://user-images.githubusercontent.com/824194/29675141-7c1a7346-88b1-11e7-82d1-317a455d4c85.JPG)
