### PR TITLE
fix for pending transactions and new block filters

### DIFF
--- a/web3/utils/formatters.py
+++ b/web3/utils/formatters.py
@@ -52,3 +52,12 @@ def apply_formatters_to_dict(formatters, value):
 def apply_formatter_to_array(formatter, value):
     for item in value:
         yield formatter(item)
+
+
+@curry
+def apply_one_of_formatters(formatter_condition_pairs, value):
+    for formatter, condition in formatter_condition_pairs:
+        if condition(value):
+            return formatter(value)
+    else:
+        raise ValueError("The provided value did not satisfy any of the formatter conditions")


### PR DESCRIPTION
### What was wrong?

Pending transaction and new block filters are failing.

```python
In [1]: from web3 import Web3, IPCProvider
In [2]: web3 = Web3(IPCProvider())
In [3]: web3.eth.filter('pending').watch(lambda x: None)
In [4]: Exception in thread Thread-42:
Traceback (most recent call last):
  File "/usr/lib/python3.5/threading.py", line 914, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.5/threading.py", line 862, in run
    self._target(*self._args, **self._kwargs)
  File "/home/jcarver/code/web3.py/web3/utils/filters.py", line 84, in _run
    changes = self.web3.eth.getFilterChanges(self.filter_id)
  File "/home/jcarver/code/web3.py/web3/eth.py", line 260, in getFilterChanges
    "eth_getFilterChanges", [filter_id],
  File "/home/jcarver/code/web3.py/web3/manager.py", line 112, in request_blocking
    response = self._make_request(method, params)
  File "/home/jcarver/code/web3.py/web3/manager.py", line 95, in _make_request
    return make_request_fn(method, params)
  File "/home/jcarver/code/web3.py/web3/middleware/attrdict.py", line 20, in middleware
    response = make_request(method, params)
  File "/home/jcarver/code/web3.py/web3/middleware/formatting.py", line 32, in middleware
    formatter(response['result']),
  File "cytoolz/functoolz.pyx", line 232, in cytoolz.functoolz.curry.__call__ (cytoolz/functoolz.c:3996)
  File "/home/jcarver/code/web3.py/venv/lib/python3.5/site-packages/eth_utils/functional.py", line 33, in inner
    return callback(fn(*args, **kwargs))
  File "/home/jcarver/code/web3.py/web3/utils/formatters.py", line 63, in apply_formatter_to_array
    yield formatter(item)
  File "cytoolz/functoolz.pyx", line 232, in cytoolz.functoolz.curry.__call__ (cytoolz/functoolz.c:3996)
  File "/home/jcarver/code/web3.py/venv/lib/python3.5/site-packages/eth_utils/functional.py", line 33, in inner
    return callback(fn(*args, **kwargs))
  File "/home/jcarver/code/web3.py/web3/utils/formatters.py", line 52, in apply_formatters_to_dict
    for key, item in value.items():
AttributeError: 'str' object has no attribute 'items'
```

### How was it fixed?

Accounted for the different return types that come back from the `eth_getFilterLogs` and `eth_getFilterChanges` RPC methods.

#### Cute Animal Picture

![o-cute-insects-570](https://user-images.githubusercontent.com/824194/29684058-c876a932-88cd-11e7-90d8-6f6a02ef6fea.jpg)

