### PR TITLE
fix call to `blockNumber` on quickstart docs

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -56,7 +56,7 @@ To use the web3 library you will need to instantiate an instance of the
 
     # or for an IPC based connection
     >>> web3 = Web3(IPCProvider())
-    >>> web3.blockNumber
+    >>> web3.eth.blockNumber
     4000000
 
 


### PR DESCRIPTION
### What was wrong?
Docs said to run `web3.blockNumber` to demonstrate that web3 was connected to node.
This fails and might turn newbies off to using the library.
```
>>> web3.blockNumber
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'Web3' object has no attribute 'blockNumber'
```


### How was it fixed?
change call to `web3.eth.blockNumber`


#### Cute Animal Picture

![Cute animal picture](http://cutecatshq.com/wp-content/uploads/2014/05/Luna-Tic-Cat-My-Cat-Luna-Is-A-Little-Crazy-About-Her-Mouse.jpg)
