### PR TITLE
New Contract Factory: ConciseContract

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,13 +30,18 @@ test:
 test-all:
 	tox
 
-docs:
+build-docs:
 	rm -f docs/web3.rst
 	rm -f docs/modules.rst
 	sphinx-apidoc -o docs/ web3
 	$(MAKE) -C docs clean
 	$(MAKE) -C docs html
+
+docs: build-docs
 	open docs/_build/html/index.html
+
+linux-docs: build-docs
+	xdg-open docs/_build/html/index.html
 
 release: clean
 	python setup.py sdist bdist_wheel upload

--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -18,6 +18,36 @@ Contract Factories
     Ethereum smart contracts.
 
 
+.. py:class:: ConciseContract(Contract())
+
+    This variation of ``Contract`` is designed for succinct read access, with
+    no impact on write access. This comes at a cost of less convenient
+    access to features like ``deploy()`` and properties like ``address``. It is
+    recommended to use the classic ``Contract`` for those use cases.
+
+    Create this type of contract with:
+
+
+    .. code-block:: python
+
+        >>> concise = web3.eth.contract(..., ContractFactoryClass=ConciseContract)
+
+
+    This variation invokes all methods as a call, so if the classic contract had a method like
+    ``contract.call().owner()``, you could call it with ``concise.owner()`` instead.
+
+    For access to send a transaction or estimate gas, you can add a keyword argument like so:
+
+
+    .. code-block:: python
+
+        >>> concise.withdraw(amount, transact={'from': eth.accounts[1], 'gas': 100000, ...})
+
+        >>>  # which is equivalent to this transaction in the classic contract:
+
+        >>> contract.transact({'from': eth.accounts[1], 'gas': 100000, ...}).withdraw(amount)
+
+
 Properties
 ----------
 

--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -631,3 +631,10 @@ Contracts
     - ``user_doc``
 
     See :doc:`./contracts` for more information about how to use contracts.
+
+.. py:method:: Eth.setContractFactory(contractFactoryClass)
+
+    Modify the default contract factory from ``Contract`` to ``contractFactoryClass``.
+    Future calls to ``Eth.contract()`` will then default to ``contractFactoryClass``.
+
+    An example of an alternative Contract Factory is ``ConciseContract``.

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -16,3 +16,6 @@ py-solc>=0.4.0
 pytest>=2.7.2
 toposort>=1.4
 web3>=2.1.0
+wheel
+sphinx
+urllib3

--- a/tests/contracts/test_concise_contract.py
+++ b/tests/contracts/test_concise_contract.py
@@ -1,0 +1,48 @@
+
+import sys
+
+import pytest
+
+from web3.contract import (
+    ConciseContract,
+    ConciseMethod,
+)
+
+if sys.version_info >= (3, 3):
+    from unittest.mock import Mock
+
+
+@pytest.mark.skipif(sys.version_info < (3, 3), reason="needs Mock library from 3.3")
+def test_concisecontract_call_default():
+    contract = Mock()
+    sweet_method = ConciseMethod(contract, 'grail')
+    sweet_method(1, 2)
+    contract.call.assert_called_once_with({})
+    contract.call().grail.assert_called_once_with(1, 2)
+
+
+@pytest.mark.skipif(sys.version_info < (3, 3), reason="needs Mock library from 3.3")
+def test_concisecontract_custom_transact():
+    contract = Mock()
+    sweet_method = ConciseMethod(contract, 'grail')
+    sweet_method(1, 2, transact={'holy': 3})
+    contract.transact.assert_called_once_with({'holy': 3})
+    contract.transact().grail.assert_called_once_with(1, 2)
+
+
+def test_class_construction_sets_class_vars(web3,
+                                            MATH_ABI,
+                                            MATH_CODE,
+                                            MATH_RUNTIME):
+    MathContract = web3.eth.contract(
+        abi=MATH_ABI,
+        bytecode=MATH_CODE,
+        bytecode_runtime=MATH_RUNTIME,
+        ContractFactoryClass=ConciseContract,
+    )
+
+    math = MathContract()
+    classic = math._classic_contract
+    assert classic.web3 == web3
+    assert classic.bytecode == MATH_CODE
+    assert classic.bytecode_runtime == MATH_RUNTIME

--- a/tests/contracts/test_concise_contract.py
+++ b/tests/contracts/test_concise_contract.py
@@ -30,6 +30,22 @@ def test_concisecontract_custom_transact():
     contract.transact().grail.assert_called_once_with(1, 2)
 
 
+@pytest.mark.skipif(sys.version_info < (3, 3), reason="needs Mock library from 3.3")
+def test_concisecontract_two_keywords_fail():
+    contract = Mock()
+    sweet_method = ConciseMethod(contract, 'grail')
+    with pytest.raises(TypeError):
+        sweet_method(1, 2, transact={'holy': 3}, call={'count_to': 4})
+
+
+@pytest.mark.skipif(sys.version_info < (3, 3), reason="needs Mock library from 3.3")
+def test_concisecontract_unknown_keyword_fails():
+    contract = Mock()
+    sweet_method = ConciseMethod(contract, 'grail')
+    with pytest.raises(TypeError):
+        sweet_method(1, 2, count={'to': 5})
+
+
 def test_class_construction_sets_class_vars(web3,
                                             MATH_ABI,
                                             MATH_CODE,

--- a/tests/core/eth-module/test_eth_contract.py
+++ b/tests/core/eth-module/test_eth_contract.py
@@ -1,4 +1,9 @@
+import sys
+
 import pytest
+
+if sys.version_info >= (3, 3):
+    from unittest.mock import Mock
 
 
 ABI = [{}]
@@ -24,3 +29,11 @@ def test_contract_address_validation(web3, args, kwargs, expected):
 
     # run without errors
     web3.eth.contract(*args, **kwargs)
+
+
+@pytest.mark.skipif(sys.version_info < (3, 3), reason="needs Mock library from 3.3")
+def test_set_contract_factory(web3):
+    factoryClass = Mock()
+    web3.eth.setContractFactory(factoryClass)
+    web3.eth.contract(contract_name='myname')
+    factoryClass.factory.assert_called_once_with(web3, 'myname')

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -781,6 +781,7 @@ class ConciseContract:
 
 
 class ConciseMethod:
+    ALLOWED_MODIFIERS = set(['call', 'estimateGas', 'transact'])
 
     def __init__(self, contract, function):
         self.__contract = contract
@@ -790,15 +791,15 @@ class ConciseMethod:
         return self.__prepared_function(**kwargs)(*args)
 
     def __prepared_function(self, **kwargs):
-        allowed_modifiers = ('call', 'estimateGas', 'transact')
         if not kwargs:
             modifier, modifier_dict = 'call', {}
         elif len(kwargs) == 1:
             modifier, modifier_dict = kwargs.popitem()
-            if modifier not in allowed_modifiers:
-                raise TypeError("The only allowed keyword arguments are: %s" % allowed_modifiers)
+            if modifier not in self.ALLOWED_MODIFIERS:
+                raise TypeError(
+                    "The only allowed keyword arguments are: %s" % self.ALLOWED_MODIFIERS)
         else:
-            raise TypeError("Use up to one keyword argument, one of: %s" % allowed_modifiers)
+            raise TypeError("Use up to one keyword argument, one of: %s" % self.ALLOWED_MODIFIERS)
         contract_modifier_func = getattr(self.__contract, modifier)
         return getattr(contract_modifier_func(modifier_dict), self.__function)
 

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -790,12 +790,15 @@ class ConciseMethod:
         return self.__prepared_function(**kwargs)(*args)
 
     def __prepared_function(self, **kwargs):
+        allowed_modifiers = ('call', 'estimateGas', 'transact')
         if not kwargs:
             modifier, modifier_dict = 'call', {}
         elif len(kwargs) == 1:
             modifier, modifier_dict = kwargs.popitem()
+            if modifier not in allowed_modifiers:
+                raise TypeError("The only allowed keyword arguments are: %s" % allowed_modifiers)
         else:
-            raise ValueError("Only use one keyword argument at a time, eg~ transact or call")
+            raise TypeError("Use up to one keyword argument, one of: %s" % allowed_modifiers)
         contract_modifier_func = getattr(self.__contract, modifier)
         return getattr(contract_modifier_func(modifier_dict), self.__function)
 

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -39,9 +39,10 @@ from web3.utils.validation import (
 
 
 class Eth(Module):
-    iban = Iban
     defaultAccount = empty
     defaultBlock = "latest"
+    defaultContractFactory = Contract
+    iban = Iban
 
     def namereg(self):
         raise NotImplementedError()
@@ -294,7 +295,7 @@ class Eth(Module):
     def contract(self,
                  *args,
                  **kwargs):
-        ContractFactoryClass = kwargs.pop('ContractFactoryClass', Contract)
+        ContractFactoryClass = kwargs.pop('ContractFactoryClass', self.defaultContractFactory)
         contract_name = kwargs.pop('contract_name', None)
 
         has_address = any((
@@ -323,6 +324,9 @@ class Eth(Module):
             except IndexError:
                 pass
             return ContractFactoryClass.factory(self.web3, contract_name, **kwargs)
+
+    def setContractFactory(self, contractFactory):
+        self.defaultContractFactory = contractFactory
 
     def getCompilers(self):
         return self.web3.manager.request_blocking("eth_getCompilers", [])


### PR DESCRIPTION
### What was wrong?

I want a contract with a shorter/cleaner style for reading out data.

### How was it fixed?

The pull adds a new Contract Factory: `ConciseContract`. The most notable feature is being able to call  `contract.owner()` instead of `contract.call().owner()`

It uses the standard factory mechanism:

```
from web3.contracts import ConciseContract
web3.eth.contract(..., ContractFactoryClass=ConciseContract)
```


All short contract calls will be issued as read-only, unless it is modified first. You can switch back to a transaction like so:

```
contract.withdraw(amount, transact={'from': eth.accounts[1], 'gas': 100000, ...})
```

Which is equivalent to this classic approach:

```
contract.transact({'from': eth.accounts[1], 'gas': 100000, ...}).withdraw(amount)
```

#### Cute Animal Picture

![Cute animal picture](https://i.pinimg.com/736x/04/5f/a0/045fa090e8c52023d3cd1935a825ee7a--baby-platypus-perry-the-platypus.jpg)