### PR TITLE
docs: the data keyword of Transaction takes bytes

### DIFF
--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -417,7 +417,7 @@ The following methods are available on the ``web3.eth`` namespace.
             startgas=100000,
             to='0xd3cda913deb6f67967b99d67acdfa1712c293601',
             value=12345,
-            data='',
+            data=b'',
         )
         >>> tx.sign(the_private_key_for_the_from_account)
         >>> raw_tx = rlp.encode(tx)


### PR DESCRIPTION
### What was wrong?

Our docs may have mislead how to use `ethereum.transactions.Transaction`. It's easy to think a string input means to pass a hex. Example: #256

### How was it fixed?

Mark it as a `bytes` type for at least a subtle hint that it takes raw data. Beyond that, it's up to people to understand the 3rd-party libraries they're using. We shouldn't document `ethereum.transactions.Transaction` within web3.py

#### Cute Animal Picture

![Cute animal picture](http://cdn.earthporm.com/wp-content/uploads/2015/05/tiny-horses-37__605.jpg)
