### PR TITLE
stand-alone: add eth.protocolVersion

### DIFF
--- a/web3/eth.py
+++ b/web3/eth.py
@@ -51,6 +51,10 @@ class Eth(Module):
         raise NotImplementedError()
 
     @property
+    def protocolVersion(self):
+        return self.web3.manager.request_blocking("eth_protocolVersion", [])
+
+    @property
     def syncing(self):
         return self.web3.manager.request_blocking("eth_syncing", [])
 


### PR DESCRIPTION
### What was wrong?

The `eth_protocolVersion` was not available under the `web3.eth` API

### How was it fixed?

Added a new `web3.eth.protocolVersion` property.

#### Cute Animal Picture

![cute_bug](https://user-images.githubusercontent.com/824194/29739097-19f12104-89f3-11e7-91a9-3c59c0056720.jpg)

