### PR TITLE
stand-alone: remove unimplemented net apis, add version

### DIFF
--- a/web3/net.py
+++ b/web3/net.py
@@ -8,12 +8,10 @@ class Net(Module):
     def listening(self):
         return self.web3.manager.request_blocking("net_listening", [])
 
-    def getListening(self, *args, **kwargs):
-        raise NotImplementedError("Async calling has not been implemented")
-
     @property
     def peerCount(self):
         return self.web3.manager.request_blocking("net_peerCount", [])
 
-    def getPeerCount(self, *args, **kwargs):
-        raise NotImplementedError("Async calling has not been implemented")
+    @property
+    def version(self):
+        return self.web3.manager.request_blocking("net_version", [])


### PR DESCRIPTION
### What was wrong?

* Async apis in the `web3.net` module that have never been implemented.
* The `net_version` was not available over the `web3.net` module.

### How was it fixed?

Removed the not implemented apis and added a `web3.net.version` property.

#### Cute Animal Picture

![98bc153ed6b87e8e6278d4a26055024b](https://user-images.githubusercontent.com/824194/29739128-c3ffcfe2-89f3-11e7-8aa7-db08f9977918.jpg)
