### PR TITLE
stand-alone: add unimplemented getLogs

### DIFF
--- a/web3/eth.py
+++ b/web3/eth.py
@@ -265,6 +265,9 @@ class Eth(Module):
             "eth_getFilterLogs", [filter_id],
         )
 
+    def getLogs(self, filter_params):
+        raise NotImplementedError("Not yet implemented")
+
     def uninstallFilter(self, filter_id):
         return self.web3.manager.request_blocking(
             "eth_uninstallFilter", [filter_id],


### PR DESCRIPTION
### What was wrong?

There is a new `eth_getLogs` API that isn't available in web3

https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getlogs

### How was it fixed?

Stubbed out a not-implemented method for it: 

#### Cute Animal Picture


![coccinellidae-ladybug](https://user-images.githubusercontent.com/824194/29739112-87d2f274-89f3-11e7-88b1-cbeaab8671d7.jpg)

