### PR TITLE
stand-alone: add stub filter_id property to Filter

### DIFF
--- a/web3/utils/filters.py
+++ b/web3/utils/filters.py
@@ -65,6 +65,7 @@ class Filter(GreenletThread):
     running = None
     stopped = False
     poll_interval = None
+    filter_id = None
 
     def __init__(self, web3, filter_id):
         self.web3 = web3


### PR DESCRIPTION
### What was wrong?

The `Filter` object was missing a stubbed out `filter_id` property like most of the rest of the objects.

### How was it fixed?

Added a `filter_id` property on the class

#### Cute Animal Picture

![bug323](https://user-images.githubusercontent.com/824194/29739136-faa6912a-89f3-11e7-9968-44c294b10056.jpg)
