### PR TITLE
provider middleware

### DIFF
--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -10,7 +10,8 @@ exposed by the web3 object and the backend or node that web3 is connecting to.
 * **Providers** are responsible for the actual communication with the
   blockchain such as sending JSON-RPC requests over HTTP or an IPC socket.
 * **Middlewares** provide hooks for monitoring and modifying requests and
-  responses to and from the provider.
+  responses to and from the provider.  These can be *global* operating on all
+  providers or specific to one provider.
 * **Managers** provide thread safety and primatives to allow for asyncronous usage of web3.
 
 Here are some common things you might want to do with these APIs.
@@ -44,17 +45,12 @@ Each web3 RPC call passes through these layers in the following manner.
                        |                ^
                        v                |
                  +-----------------------------+
-                 |     First  Middleware       |
+                 |     Global Middlewares      |
                  +-----------------------------+
                        |                ^
                        v                |
                  +-----------------------------+
-                 |             ...             |
-                 +-----------------------------+
-                       |                ^
-                       v                |
-                 +-----------------------------+
-                 |      Last  Middleware       |
+                 |    Provider Middlewares     |
                  +-----------------------------+
                        |                ^
                        v                |
@@ -129,6 +125,22 @@ request is issued to the next configured provider.  If no providers are able to
 handle the request then a ``web3.exceptions.UnhandledRequest`` error will be
 raised.
 
+.. py:property:: BaseProvider.middlewares
+
+    This should be an iterable of middlewares.
+
+
+.. py:method:: BaseProvider.add_middleware(middleware)
+
+    This method adds the given middleware to the beginning or outside of the
+    provider's middleware stack.
+
+
+.. py:method:: BaseProvider.clear_middlewares()
+
+    This method clears all provider middlewares.
+
+
 
 Middlewares
 -----------
@@ -196,13 +208,13 @@ The ``RequestManager`` object exposes two apis for managing middlewares.  Both
 of these methods are also exposed on the ``Web3`` object for convenience.
 
 
-.. method:: RequestManager.add_middleware(middleware)
+.. py:method:: RequestManager.add_middleware(middleware)
 
     This method adds the given middleware to the beginning or outside of the
     middleware stack.
 
 
-.. method:: RequestManager.clear_middlewares()
+.. py:method:: RequestManager.clear_middlewares()
 
     This method clears all middlewares.
 

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -48,7 +48,7 @@ class RequestManager(object):
     def _generate_request_functions(self):
         self._wrapped_provider_request_functions = {
             index: combine_middlewares(
-                middlewares=self._middlewares,
+                middlewares=tuple(self.middlewares) + tuple(provider.middlewares),
                 web3=self.web3,
                 provider_request_fn=provider.make_request,
             )

--- a/web3/providers/base.py
+++ b/web3/providers/base.py
@@ -11,6 +11,25 @@ from eth_utils import (
 
 
 class BaseProvider(object):
+    _middlewares = None
+
+    @property
+    def middlewares(self):
+        return self._middlewares or tuple()
+
+    @middlewares.setter
+    def middlewares(self, value):
+        self._middlewares = tuple(value)
+
+    def add_middleware(self, middleware):
+        self.middlewares = tuple(itertools.chain(
+            [middleware],
+            self.middlewares,
+        ))
+
+    def clear_middlewares(self):
+        self.middlewares = tuple()
+
     def make_request(self, method, params):
         raise NotImplementedError("Providers must implement this method")
 


### PR DESCRIPTION
### What was wrong?

Providers need to be able to have their own middleware to be able to clean up provider specific issues.

### How was it fixed?

Added a middleware API to the provider class.

#### Cute Animal Picture

![cute_bug-1600x900](https://user-images.githubusercontent.com/824194/29739166-9d92243a-89f4-11e7-838b-b19e449b811c.jpg)
