### PR TITLE
Piper/ethtestrpc provider middleware

### DIFF
--- a/tests/version-module/test_web3_version_props.py
+++ b/tests/version-module/test_web3_version_props.py
@@ -13,8 +13,8 @@ def test_node_property(web3):
 
 
 def test_network_property(web3):
-    assert web3.version.network in {1, 2, 3, 1234}
+    assert web3.version.network in {'1', '2', '3', '1234'}
 
 
 def test_ethereum_property(web3):
-    assert web3.version.ethereum == 63
+    assert web3.version.ethereum.isdigit()

--- a/web3/providers/tester.py
+++ b/web3/providers/tester.py
@@ -1,6 +1,20 @@
+from eth_utils import (
+    is_integer,
+    is_string,
+)
+
+from web3.middleware import (
+    construct_formatting_middleware,
+)
+
 from web3.utils.compat import (
     make_server,
     spawn,
+)
+from web3.utils.formatters import (
+    hex_to_integer,
+    apply_formatter_if,
+    apply_formatter_at_index,
 )
 
 from .base import BaseProvider  # noqa: E402
@@ -15,7 +29,28 @@ def is_testrpc_available():
         return False
 
 
+to_integer_if_hex = apply_formatter_if(hex_to_integer, is_string)
+
+
+ethtestrpc_middleware = construct_formatting_middleware(
+    request_formatters={
+        'eth_uninstallFilter': apply_formatter_at_index(to_integer_if_hex, 0),
+        'eth_getFilterChanges': apply_formatter_at_index(to_integer_if_hex, 0),
+        'eth_getFilterLogs': apply_formatter_at_index(to_integer_if_hex, 0),
+    },
+    result_formatters={
+        # Eth
+        'eth_newFilter': apply_formatter_if(hex, is_integer),
+        'eth_protocolVersion': apply_formatter_if(str, is_integer),
+        # Net
+        'net_version': apply_formatter_if(str, is_integer),
+    },
+)
+
+
 class EthereumTesterProvider(BaseProvider):
+    middlewares = [ethtestrpc_middleware]
+
     def __init__(self,
                  *args,
                  **kwargs):
@@ -45,6 +80,8 @@ class EthereumTesterProvider(BaseProvider):
 
 
 class TestRPCProvider(HTTPProvider):
+    middlewares = [ethtestrpc_middleware]
+
     def __init__(self, host="127.0.0.1", port=8545, *args, **kwargs):
         if not is_testrpc_available():
             raise Exception("`TestRPCProvider` requires the `eth-testrpc` package to be installed")


### PR DESCRIPTION
Depends on https://github.com/pipermerriam/web3.py/pull/266

### What was wrong?

The eth-testrpc based providers needed some cleanup that could be done in the middleware layer

### How was it fixed?

Added an ethtestrpc specific middleware to them

#### Cute Animal Picture

![o-cute-insects-570](https://user-images.githubusercontent.com/824194/29739185-ef55efc2-89f4-11e7-9aec-a67cd51f40bd.jpg)
