### PR TITLE
New stalecheck middleware

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,7 @@ Contents
     filters
     contracts
     providers
+    middleware
     examples
     web3.main
     web3.eth

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -142,6 +142,8 @@ raised.
 
 
 
+.. _internals__middlewares:
+
 Middlewares
 -----------
 

--- a/docs/middleware.rst
+++ b/docs/middleware.rst
@@ -1,0 +1,87 @@
+Middleware
+==========
+
+There is a stack of middlewares managed by Web3. They sit between the public Web3 methods and the
+:doc:`providers`, which handle native communication with the Ethereum client. Each layer
+can modify the request and/or response. Some middlewares are enabled by default, and
+others are available for optional use.
+
+Each middleware in the stack gets invoked before the request reaches the provider, and then
+processes the result after the provider returns, in reverse order. However, it is
+possible for a middleware to return early from a
+call without the request ever getting to the provider (or even reaching the middlewares further down
+the stack).
+
+More information is available in the "Internals: :ref:`internals__middlewares`" section.
+
+
+Default Middleware
+------------------
+
+Some middlewares are added by default if you do not supply any. The defaults
+are likely to change regularly, so this list may not include the latest version's defaults.
+You can find the latest defaults in the constructor in `web3/manager.py`
+
+AttributeDict
+~~~~~~~~~~~~
+
+.. py:method:: web3.middleware.attrdict_middleware
+
+    This middleware converts the output of a function from a dictionary to an ``AttributeDict``
+    which enables dot-syntax access, like ``eth.getBlock('latest').number``
+    in addition to ``eth.getBlock('latest')['number']``.
+
+Pythonic
+~~~~~~~~~~~~
+
+.. py:method:: web3.middleware.pythonic_middleware
+
+    This converts arguments and returned values to python primitives,
+    where appropriate. For example, it converts the raw hex string returned by the RPC call
+    ``eth_blockNumber`` into an ``int``.
+
+Built-in Middleware
+------------------
+
+Web3 ships with middleware for custom use, as desired. Middleware can be added after creating
+your Web3 object, like:
+
+.. code-block:: python
+
+    w3 = Web3(...)
+    w3.add_middleware(my_middleware)
+
+Alternatively, you can pass in middlewares to the Web3 constructor.
+
+.. code-block:: python
+
+    Web3(middlewares=[my_middleware1, my_middleware2])
+
+.. warning::
+  This will
+  *replace* the default middlewares. To keep the default functionality,
+  either use ``add_middleware()`` from above, or add the default middlewares to your list of
+  new middlewares.
+
+Stalecheck
+~~~~~~~~~~~~
+
+.. py:method:: web3.middleware.make_stalecheck_middleware(allowable_delay)
+
+    This middleware checks how stale the blockchain is, and interrupts calls with a failure
+    if the blockchain is too old.
+
+    * ``allowable_delay`` is the length in seconds that the blockchain is allowed to be
+      behind of ``time.time()``
+
+    Because this middleware takes an argument, you must create the middleware
+    with a method call.
+
+    .. code-block:: python
+
+        two_day_stalecheck = make_stalecheck_middleware(60 * 60 * 24 * 2)
+        web3.add_middleware(two_day_stalecheck)
+
+    If the latest block in the blockchain is older than 2 days in this example, then the
+    middleware will raise a ``StaleBlockchain`` exception on every call except
+    ``web3.eth.getBlock()``.

--- a/tests/core/middleware/test_stalecheck.py
+++ b/tests/core/middleware/test_stalecheck.py
@@ -1,0 +1,104 @@
+
+import pytest
+import sys
+
+from web3.middleware.stalecheck import (
+    _isfresh,
+    make_stalecheck_middleware,
+    StaleBlockchain,
+)
+
+if sys.version_info >= (3, 3):
+    from unittest.mock import Mock, patch
+
+
+pytestmark = pytest.mark.skipif(sys.version_info < (3, 3), reason="needs Mock library from 3.3")
+
+
+@pytest.fixture
+def now():
+    return 3141592653
+
+
+@pytest.fixture
+def days_fresh():
+    return 3
+
+
+@pytest.fixture
+def request_middleware(days_fresh):
+    middleware = make_stalecheck_middleware(days=days_fresh)
+    make_request, web3 = Mock(), Mock()
+    initialized = middleware(make_request, web3)
+    # for easier mocking, later:
+    initialized.web3 = web3
+    initialized.make_request = make_request
+    return initialized
+
+
+class BlockStub():
+    def __init__(self, _timestamp):
+        self.timestamp = _timestamp
+        self.number = 123
+
+
+def test_is_not_fresh_with_no_block():
+    assert not _isfresh(None, 1)
+
+
+def test_is_not_fresh(now):
+    with patch('time.time', return_value=now):
+        SECONDS_ALLOWED = 2 * 86400
+        stale = BlockStub(now - SECONDS_ALLOWED - 1)
+        assert not _isfresh(stale, SECONDS_ALLOWED)
+
+
+def test_is_fresh(now):
+    with patch('time.time', return_value=now):
+        SECONDS_ALLOWED = 2 * 86400
+        stale = BlockStub(now - SECONDS_ALLOWED)
+        assert _isfresh(stale, SECONDS_ALLOWED)
+
+
+def test_stalecheck_pass(request_middleware):
+    with patch('web3.middleware.stalecheck._isfresh', return_value=True):
+        method, params = Mock(), Mock()
+        request_middleware(method, params)
+        request_middleware.make_request.assert_called_once_with(method, params)
+
+
+def test_stalecheck_fail(request_middleware, now):
+    with patch('web3.middleware.stalecheck._isfresh', return_value=False):
+        method, params = Mock(), Mock()
+        request_middleware.web3.eth.getBlock.return_value = BlockStub(now)
+        with pytest.raises(StaleBlockchain):
+            request_middleware(method, params)
+
+
+@pytest.mark.parametrize(
+    'rpc_method',
+    [
+        'eth_getBlockByHash',
+        'eth_getBlockByNumber',
+        'eth_getBlockTransactionCountByHash',
+        'eth_getBlockTransactionCountByNumber',
+        'eth_getTransactionByBlockHashAndIndex',
+        'eth_getTransactionByBlockNumberAndIndex',
+        'eth_getUncleCountByBlockHash',
+        'eth_getUncleCountByBlockNumber',
+    ]
+)
+def test_stalecheck_ignores_get_by_block_methods(request_middleware, rpc_method):
+    # This is especially critical for getBlock('latest') which would cause infinite recursion
+    with patch('web3.middleware.stalecheck._isfresh', return_value=True):
+        params = Mock()
+        request_middleware(rpc_method, params)
+        assert not request_middleware.web3.eth.getBlock.called
+
+
+def test_stalecheck_calls_isfresh_with_block_and_time(request_middleware, days_fresh):
+    with patch('web3.middleware.stalecheck._isfresh', return_value=True) as freshspy:
+        method, params, block = Mock(), Mock(), Mock()
+        request_middleware.web3.eth.getBlock.return_value = block
+        request_middleware(method, params)
+        freshspy.assert_called_once_with(block, 86400 * days_fresh)

--- a/tests/core/middleware/test_stalecheck.py
+++ b/tests/core/middleware/test_stalecheck.py
@@ -2,9 +2,9 @@
 import pytest
 import sys
 
+from web3.middleware import make_stalecheck_middleware
 from web3.middleware.stalecheck import (
     _isfresh,
-    make_stalecheck_middleware,
     StaleBlockchain,
 )
 from web3.utils.datastructures import AttributeDict

--- a/web3/exceptions.py
+++ b/web3/exceptions.py
@@ -1,3 +1,7 @@
+import datetime
+import time
+
+
 class BadFunctionCallOutput(Exception):
     """
     We failed to decode ABI output.
@@ -20,3 +24,17 @@ class UnhandledRequest(Exception):
     Raised by the manager when none of it's providers responds to a request.
     """
     pass
+
+
+class StaleBlockchain(Exception):
+    """
+    Raised by the stalecheck_middleware when the latest block is too old.
+    """
+    def __init__(self, block, allowable_delay):
+        last_block_date = datetime.datetime.fromtimestamp(block.timestamp).strftime('%c')
+        message = (
+            "The latest block, #%d, is %d seconds old, but is only allowed to be %d s old. "
+            "The date of the most recent block is %s. Continue syncing and try again..." %
+            (block.number, time.time() - block.timestamp, allowable_delay, last_block_date)
+        )
+        super().__init__(message, block, allowable_delay)

--- a/web3/exceptions.py
+++ b/web3/exceptions.py
@@ -38,3 +38,6 @@ class StaleBlockchain(Exception):
             (block.number, time.time() - block.timestamp, allowable_delay, last_block_date)
         )
         super().__init__(message, block, allowable_delay)
+
+    def __str__(self):
+        return self.args[0]

--- a/web3/middleware/__init__.py
+++ b/web3/middleware/__init__.py
@@ -10,6 +10,9 @@ from .exception_handling import (  # noqa: F401
 from .pythonic import (  # noqa: F401
     pythonic_middleware,
 )
+from .stalecheck import (  # noqa: F401
+    make_stalecheck_middleware,
+)
 from .attrdict import (  # noqa: F401
     attrdict_middleware,
 )

--- a/web3/middleware/stalecheck.py
+++ b/web3/middleware/stalecheck.py
@@ -1,0 +1,55 @@
+import datetime
+import time
+
+
+SKIP_STALECHECK_FOR_METHODS = set([
+    'eth_getBlockByHash',
+    'eth_getBlockByNumber',
+    'eth_getBlockTransactionCountByHash',
+    'eth_getBlockTransactionCountByNumber',
+    'eth_getTransactionByBlockHashAndIndex',
+    'eth_getTransactionByBlockNumberAndIndex',
+    'eth_getUncleCountByBlockHash',
+    'eth_getUncleCountByBlockNumber',
+])
+
+
+def _isfresh(block, allowable_delay):
+    return block and time.time() - block.timestamp <= allowable_delay
+
+
+def make_stalecheck_middleware(**kwargs):
+    '''
+    Use to require that a function will run only of the blockchain is recently updated.
+
+    This middleware takes an argument, so unlike other middleware, you must make the middleware
+    with a method call.
+    For example: `make_stalecheck_middleware(hours=12)`
+
+    If the latest block in the chain is older than 12 hours ago in this example, then the
+    middleware will raise a StaleBlockchain exception.
+
+    `make_stalecheck_middleware(...)` takes the same keyword arguments as datetime.timedelta()
+    '''
+    allowable_delay = datetime.timedelta(**kwargs).total_seconds()
+
+    def stalecheck_middleware(make_request, web3):
+        def middleware(method, params):
+            if method not in SKIP_STALECHECK_FOR_METHODS:
+                last_block = web3.eth.getBlock('latest')
+                if not _isfresh(last_block, allowable_delay):
+                    raise StaleBlockchain(last_block, allowable_delay)
+
+            return make_request(method, params)
+        return middleware
+    return stalecheck_middleware
+
+
+class StaleBlockchain(Exception):
+    def __init__(self, block, allowable_delay):
+        last_block_date = datetime.datetime.fromtimestamp(block.timestamp).strftime('%c')
+        super().__init__(
+            "The latest block, #%d, is %d seconds old, but is only allowed to be %d s old. "
+            "The date of the most recent block is %s. Continue syncing and try again..." %
+            (block.number, time.time() - block.timestamp, allowable_delay, last_block_date)
+        )

--- a/web3/middleware/stalecheck.py
+++ b/web3/middleware/stalecheck.py
@@ -1,5 +1,3 @@
-from collections import defaultdict
-import datetime
 import time
 
 from web3.exceptions import StaleBlockchain
@@ -13,19 +11,19 @@ def _isfresh(block, allowable_delay):
     return block and time.time() - block['timestamp'] <= allowable_delay
 
 
-def make_stalecheck_middleware(seconds=0, minutes=0, hours=0, days=0):
+def make_stalecheck_middleware(allowable_delay=0):
     '''
     Use to require that a function will run only of the blockchain is recently updated.
 
     This middleware takes an argument, so unlike other middleware, you must make the middleware
     with a method call.
-    For example: `make_stalecheck_middleware(hours=6, days=1)`
+    For example: `make_stalecheck_middleware(allowable_delay=60*5)`
 
-    If the latest block in the chain is older than 30 hours ago in this example, then the
+    If the latest block in the chain is older than 5 minutes in this example, then the
     middleware will raise a StaleBlockchain exception.
     '''
-    allowable_delta = datetime.timedelta(seconds=seconds, minutes=minutes, hours=hours, days=days)
-    allowable_delay = allowable_delta.total_seconds()
+    if not allowable_delay:
+        raise ValueError("You must set a non-zero allowable delay for this middleware")
 
     def stalecheck_middleware(make_request, web3):
         cache = {'latest': None}

--- a/web3/middleware/stalecheck.py
+++ b/web3/middleware/stalecheck.py
@@ -5,14 +5,7 @@ import time
 from web3.exceptions import StaleBlockchain
 
 SKIP_STALECHECK_FOR_METHODS = set([
-    'eth_getBlockByHash',
     'eth_getBlockByNumber',
-    'eth_getBlockTransactionCountByHash',
-    'eth_getBlockTransactionCountByNumber',
-    'eth_getTransactionByBlockHashAndIndex',
-    'eth_getTransactionByBlockNumberAndIndex',
-    'eth_getUncleCountByBlockHash',
-    'eth_getUncleCountByBlockNumber',
 ])
 
 

--- a/web3/middleware/stalecheck.py
+++ b/web3/middleware/stalecheck.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 import datetime
 import time
 
+from web3.exceptions import StaleBlockchain
 
 SKIP_STALECHECK_FOR_METHODS = set([
     'eth_getBlockByHash',
@@ -56,14 +57,3 @@ def make_stalecheck_middleware(**kwargs):
             return make_request(method, params)
         return middleware
     return stalecheck_middleware
-
-
-class StaleBlockchain(Exception):
-    def __init__(self, block, allowable_delay):
-        last_block_date = datetime.datetime.fromtimestamp(block.timestamp).strftime('%c')
-        message = (
-            "The latest block, #%d, is %d seconds old, but is only allowed to be %d s old. "
-            "The date of the most recent block is %s. Continue syncing and try again..." %
-            (block.number, time.time() - block.timestamp, allowable_delay, last_block_date)
-        )
-        super().__init__(message, block, allowable_delay)

--- a/web3/middleware/stalecheck.py
+++ b/web3/middleware/stalecheck.py
@@ -20,19 +20,6 @@ def _isfresh(block, allowable_delay):
     return block and time.time() - block['timestamp'] <= allowable_delay
 
 
-def assert_fresh(web3, cached_blocks, allowable_delay):
-    last_cached = cached_blocks[web3.providers]
-    if _isfresh(last_cached, allowable_delay):
-        return True
-    else:
-        last_block = web3.eth.getBlock('latest')
-        if _isfresh(last_block, allowable_delay):
-            cached_blocks[web3.providers] = last_block
-            return True
-        else:
-            raise StaleBlockchain(last_block, allowable_delay)
-
-
 def make_stalecheck_middleware(seconds=0, minutes=0, hours=0, days=0):
     '''
     Use to require that a function will run only of the blockchain is recently updated.
@@ -46,12 +33,20 @@ def make_stalecheck_middleware(seconds=0, minutes=0, hours=0, days=0):
     '''
     allowable_delta = datetime.timedelta(seconds=seconds, minutes=minutes, hours=hours, days=days)
     allowable_delay = allowable_delta.total_seconds()
-    cached_blocks = defaultdict(lambda: None)
 
     def stalecheck_middleware(make_request, web3):
+        cache = {'latest': None}
+
         def middleware(method, params):
             if method not in SKIP_STALECHECK_FOR_METHODS:
-                assert_fresh(web3, cached_blocks, allowable_delay)
+                if _isfresh(cache['latest'], allowable_delay):
+                    pass
+                else:
+                    latest = web3.eth.getBlock('latest')
+                    if _isfresh(latest, allowable_delay):
+                        cache['latest'] = latest
+                    else:
+                        raise StaleBlockchain(latest, allowable_delay)
 
             return make_request(method, params)
         return middleware

--- a/web3/middleware/stalecheck.py
+++ b/web3/middleware/stalecheck.py
@@ -61,8 +61,9 @@ def make_stalecheck_middleware(**kwargs):
 class StaleBlockchain(Exception):
     def __init__(self, block, allowable_delay):
         last_block_date = datetime.datetime.fromtimestamp(block.timestamp).strftime('%c')
-        super().__init__(
+        message = (
             "The latest block, #%d, is %d seconds old, but is only allowed to be %d s old. "
             "The date of the most recent block is %s. Continue syncing and try again..." %
             (block.number, time.time() - block.timestamp, allowable_delay, last_block_date)
         )
+        super().__init__(message, block, allowable_delay)

--- a/web3/middleware/stalecheck.py
+++ b/web3/middleware/stalecheck.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 import datetime
 import time
 
@@ -15,7 +16,20 @@ SKIP_STALECHECK_FOR_METHODS = set([
 
 
 def _isfresh(block, allowable_delay):
-    return block and time.time() - block.timestamp <= allowable_delay
+    return block and time.time() - block['timestamp'] <= allowable_delay
+
+
+def assert_fresh(web3, cached_blocks, allowable_delay):
+    last_cached = cached_blocks[web3.providers]
+    if _isfresh(last_cached, allowable_delay):
+        return True
+    else:
+        last_block = web3.eth.getBlock('latest')
+        if _isfresh(last_block, allowable_delay):
+            cached_blocks[web3.providers] = last_block
+            return True
+        else:
+            raise StaleBlockchain(last_block, allowable_delay)
 
 
 def make_stalecheck_middleware(**kwargs):
@@ -32,13 +46,12 @@ def make_stalecheck_middleware(**kwargs):
     `make_stalecheck_middleware(...)` takes the same keyword arguments as datetime.timedelta()
     '''
     allowable_delay = datetime.timedelta(**kwargs).total_seconds()
+    cached_blocks = defaultdict(lambda: None)
 
     def stalecheck_middleware(make_request, web3):
         def middleware(method, params):
             if method not in SKIP_STALECHECK_FOR_METHODS:
-                last_block = web3.eth.getBlock('latest')
-                if not _isfresh(last_block, allowable_delay):
-                    raise StaleBlockchain(last_block, allowable_delay)
+                assert_fresh(web3, cached_blocks, allowable_delay)
 
             return make_request(method, params)
         return middleware

--- a/web3/middleware/stalecheck.py
+++ b/web3/middleware/stalecheck.py
@@ -11,25 +11,27 @@ def _isfresh(block, allowable_delay):
     return block and time.time() - block['timestamp'] <= allowable_delay
 
 
-def make_stalecheck_middleware(allowable_delay=0):
+def make_stalecheck_middleware(
+        allowable_delay,
+        skip_stalecheck_for_methods=SKIP_STALECHECK_FOR_METHODS):
     '''
     Use to require that a function will run only of the blockchain is recently updated.
 
     This middleware takes an argument, so unlike other middleware, you must make the middleware
     with a method call.
-    For example: `make_stalecheck_middleware(allowable_delay=60*5)`
+    For example: `make_stalecheck_middleware(60*5)`
 
     If the latest block in the chain is older than 5 minutes in this example, then the
     middleware will raise a StaleBlockchain exception.
     '''
-    if not allowable_delay:
-        raise ValueError("You must set a non-zero allowable delay for this middleware")
+    if allowable_delay <= 0:
+        raise ValueError("You must set a positive allowable_delay in seconds for this middleware")
 
     def stalecheck_middleware(make_request, web3):
         cache = {'latest': None}
 
         def middleware(method, params):
-            if method not in SKIP_STALECHECK_FOR_METHODS:
+            if method not in skip_stalecheck_for_methods:
                 if _isfresh(cache['latest'], allowable_delay):
                     pass
                 else:

--- a/web3/middleware/stalecheck.py
+++ b/web3/middleware/stalecheck.py
@@ -33,20 +33,19 @@ def assert_fresh(web3, cached_blocks, allowable_delay):
             raise StaleBlockchain(last_block, allowable_delay)
 
 
-def make_stalecheck_middleware(**kwargs):
+def make_stalecheck_middleware(seconds=0, minutes=0, hours=0, days=0):
     '''
     Use to require that a function will run only of the blockchain is recently updated.
 
     This middleware takes an argument, so unlike other middleware, you must make the middleware
     with a method call.
-    For example: `make_stalecheck_middleware(hours=12)`
+    For example: `make_stalecheck_middleware(hours=6, days=1)`
 
-    If the latest block in the chain is older than 12 hours ago in this example, then the
+    If the latest block in the chain is older than 30 hours ago in this example, then the
     middleware will raise a StaleBlockchain exception.
-
-    `make_stalecheck_middleware(...)` takes the same keyword arguments as datetime.timedelta()
     '''
-    allowable_delay = datetime.timedelta(**kwargs).total_seconds()
+    allowable_delta = datetime.timedelta(seconds=seconds, minutes=minutes, hours=hours, days=days)
+    allowable_delay = allowable_delta.total_seconds()
     cached_blocks = defaultdict(lambda: None)
 
     def stalecheck_middleware(make_request, web3):


### PR DESCRIPTION
### What was wrong?

An example:

It can be pretty bad news to resolve an ENS name from old blockchain data, so an ENS tool would likely prefer an exception over silent, stale success.

### How was it fixed?

Users can add this new middleware to raise an exception if the blockchain is too old.

Added a new stalecheck middleware. It's generated and added like so:

```
stalecheck_middleware = make_stalecheck_middleware(hours=36)
web3.add_middleware(stalecheck_middleware)
```

TODO for me: add a section in the docs for Middleware, focusing on examples for the optional middleware.

#### Cute Animal Picture

![Cute animal picture](http://yesofcorsa.com/wp-content/uploads/2016/09/Badger-Wallpaper-For-PC-1024x685.jpg)
