### PR TITLE
Piper/ethereum tester library integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,11 @@ env:
     - TOX_POSARGS="-e py27-core-gevent"
     - TOX_POSARGS="-e py34-core-gevent"
     - TOX_POSARGS="-e py35-core-gevent"
+    # eth-testrpc
     - TOX_POSARGS="-e py27-integration-ethtestrpc -e py34-integration-ethtestrpc -e py35-integration-ethtestrpc"
+    # ethereum-tester
+    - TOX_POSARGS="-e py27-integration-ethtester -e py34-integration-ethtester -e py35-integration-ethtester"
+    # go-ethereum
     - TOX_POSARGS="-e py27-integration-goethereum -e py34-integration-goethereum -e py35-integration-goethereum" GETH_VERSION=v1.6.0
     - TOX_POSARGS="-e py27-integration-goethereum -e py34-integration-goethereum -e py35-integration-goethereum" GETH_VERSION=v1.6.1
     - TOX_POSARGS="-e py27-integration-goethereum -e py34-integration-goethereum -e py35-integration-goethereum" GETH_VERSION=v1.6.4

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -68,11 +68,36 @@ IPCProvider
         >>> web3 = Web3(Web3.IPCProvider("~/Library/Ethereum/geth.ipc")
 
 
-.. py:currentmodule:: web3.providers.tester
-
+.. py:currentmodule:: web3.providers.eth_tester
 
 EthereumTesterProvider
 ~~~~~~~~~~~~~~~~~~~~~~
+
+.. warning:: Experimental:  This provider is experimental and should be used with caution.
+
+.. py:class:: EthereumTesterProvider(eth_tester)
+
+    This provider integrates with the ``ethereum-tester`` library.  The
+    ``eth_tester`` constructor argument should be an instance of the
+    ``eth_tester.EthereumTester`` class provided by the ``ethereum-tester``
+    library.  See the ``ethereum-tester`` library documentation for
+    instructions on how to use the library.
+
+    .. code-block:: python
+
+        >>> from web3 import Web3
+        >>> from web3.providers.eth_tester import EthereumTesterProvider
+        >>> from eth_tester import EthereumTester
+        >>> eth_tester = EthereumTester()
+        >>> web3 = Web3(EthereumTesterProvider(eth_tester))
+
+
+
+.. py:currentmodule:: web3.providers.tester
+
+
+EthereumTesterProvider (legacy)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. warning:: Pending Deprecation:  This provider is being deprecated soon in favor of the newly created ethereum-tester library.
 

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -1,0 +1,188 @@
+from __future__ import unicode_literals
+
+import functools
+import sys
+
+import pytest
+
+from eth_utils import (
+    is_address,
+    is_dict,
+)
+
+from web3 import Web3
+
+from web3.utils.module_testing import (
+    EthModuleTest,
+    NetModuleTest,
+    PersonalModuleTest,
+    VersionModuleTest,
+    Web3ModuleTest,
+)
+from web3.utils.module_testing.math_contract import (
+    MATH_BYTECODE,
+    MATH_ABI,
+)
+from web3.providers.eth_tester import (
+    EthereumTesterProvider,
+)
+
+from eth_tester import EthereumTester
+
+
+pytestmark = pytest.mark.filterwarnings("ignore:implicit cast from 'char *'")
+
+
+@pytest.fixture(scope="session")
+def eth_tester():
+    _eth_tester = EthereumTester()
+    return _eth_tester
+
+
+@pytest.fixture(scope="session")
+def eth_tester_provider(eth_tester):
+    provider = EthereumTesterProvider(eth_tester)
+    return provider
+
+
+@pytest.fixture(scope="session")
+def web3(eth_tester_provider):
+    _web3 = Web3(eth_tester_provider)
+    return _web3
+
+
+@pytest.fixture(scope="session")
+def math_contract_factory(web3):
+    contract_factory = web3.eth.contract(abi=MATH_ABI, bytecode=MATH_BYTECODE)
+    return contract_factory
+
+
+@pytest.fixture(scope="session")
+def math_contract_deploy_txn_hash(web3, math_contract_factory):
+    deploy_txn_hash = math_contract_factory.deploy({'from': web3.eth.coinbase})
+    return deploy_txn_hash
+
+
+@pytest.fixture(scope="session")
+def math_contract(web3, math_contract_factory, math_contract_deploy_txn_hash):
+    deploy_receipt = web3.eth.getTransactionReceipt(math_contract_deploy_txn_hash)
+    assert is_dict(deploy_receipt)
+    contract_address = deploy_receipt['contractAddress']
+    assert is_address(contract_address)
+    return math_contract_factory(contract_address)
+
+
+@pytest.fixture(scope="session")
+def empty_block(web3):
+    web3.testing.mine()
+    block = web3.eth.getBlock("latest")
+    assert not block['transactions']
+    return block
+
+
+@pytest.fixture(scope="session")
+def block_with_txn(web3):
+    txn_hash = web3.eth.sendTransaction({
+        'from': web3.eth.coinbase,
+        'to': web3.eth.coinbase,
+        'value': 1,
+        'gas': 21000,
+        'gas_price': 1,
+    })
+    txn = web3.eth.getTransaction(txn_hash)
+    block = web3.eth.getBlock(txn['blockNumber'])
+    return block
+
+
+@pytest.fixture(scope="session")
+def mined_txn_hash(block_with_txn):
+    return block_with_txn['transactions'][0]
+
+
+UNLOCKABLE_PRIVATE_KEY = '0x392f63a79b1ff8774845f3fa69de4a13800a59e7083f5187f1558f0797ad0f01'
+
+
+@pytest.fixture(scope='session')
+def unlockable_account_pw(web3):
+    return 'web3-testing'
+
+
+@pytest.fixture(scope='session')
+def unlockable_account(web3, unlockable_account_pw):
+    account = web3.personal.importRawKey(UNLOCKABLE_PRIVATE_KEY, unlockable_account_pw)
+    web3.eth.sendTransaction({
+        'from': web3.eth.coinbase,
+        'to': account,
+        'value': web3.toWei(10, 'ether'),
+    })
+    yield account
+
+
+@pytest.fixture
+def unlocked_account(web3, unlockable_account, unlockable_account_pw):
+    web3.personal.unlockAccount(unlockable_account, unlockable_account_pw)
+    yield unlockable_account
+    web3.personal.lockAccount(unlockable_account)
+
+
+@pytest.fixture(scope="session")
+def funded_account_for_raw_txn(web3):
+    account = '0x39eeed73fb1d3855e90cbd42f348b3d7b340aaa6'
+    web3.eth.sendTransaction({
+        'from': web3.eth.coinbase,
+        'to': account,
+        'value': web3.toWei(10, 'ether'),
+        'gas': 21000,
+        'gas_price': 1,
+    })
+    return account
+
+
+class TestEthereumTesterWeb3Module(Web3ModuleTest):
+    def _check_web3_clientVersion(self, client_version):
+        assert client_version.startswith('EthereumTester/')
+
+
+def not_implemented(method, exc_type=NotImplementedError):
+    @functools.wraps(method)
+    def inner(*args, **kwargs):
+        if sys.version_info.major == 2:
+            # pytest doesn't do the right thing with the fixture arguments in
+            # python2 so just don't run it.
+            return
+        with pytest.raises(exc_type):
+            method(*args, **kwargs)
+    return inner
+
+
+class TestEthereumTesterEthModule(EthModuleTest):
+    test_eth_sign = not_implemented(EthModuleTest.test_eth_sign, ValueError)
+    test_eth_sendRawTransaction = not_implemented(
+        EthModuleTest.test_eth_sendRawTransaction,
+        ValueError,
+    )
+
+    def test_eth_getTransactionReceipt_unmined(self, eth_tester, web3, unlocked_account):
+        eth_tester.disable_auto_mine_transactions()
+        try:
+            super(TestEthereumTesterEthModule, self).test_eth_getTransactionReceipt_unmined(
+                web3, unlocked_account,
+            )
+        finally:
+            eth_tester.enable_auto_mine_transactions()
+            eth_tester.mine_block()
+
+
+class TestEthereumTesterVersionModule(VersionModuleTest):
+    pass
+
+
+class TestEthereumTesterNetModule(NetModuleTest):
+    pass
+
+
+class TestEthereumTesterPersonalModule(PersonalModuleTest):
+    test_personal_sign_and_ecrecover = not_implemented(
+        PersonalModuleTest.test_personal_sign_and_ecrecover,
+        ValueError,
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=
     py{27,34,35}-core-{gevent,stdlib}
-    py{27,34,35}-integration-{ethtestrpc,goethereum}
+    py{27,34,35}-integration-{ethtestrpc,goethereum,ethtester}
     flake8
 
 [flake8]
@@ -15,9 +15,11 @@ commands=
     core: py.test {posargs:tests/core}
     integration-ethtestrpc: py.test {posargs:tests/integration/test_ethtestrpc.py}
     integration-goethereum: py.test {posargs:tests/integration/test_goethereum.py}
+    integration-ethtester: py.test {posargs:tests/integration/test_ethereum_tester.py}
 deps =
     -r{toxinidir}/requirements-dev.txt
     gevent: -r{toxinidir}/requirements-gevent.txt
+    ethtester: ethereum-tester>=0.1.0-alpha.6
 setenv =
     gevent: THREADING_BACKEND=gevent
 passenv =

--- a/web3/providers/eth_tester/__init__.py
+++ b/web3/providers/eth_tester/__init__.py
@@ -1,0 +1,6 @@
+from __future__ import absolute_import
+
+
+from .main import (  # noqa: F401
+    EthereumTesterProvider,
+)

--- a/web3/providers/eth_tester/main.py
+++ b/web3/providers/eth_tester/main.py
@@ -1,0 +1,383 @@
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
+
+import operator
+import random
+import sys
+
+from cytoolz.functoolz import (
+    excepts,
+    compose,
+    curry,
+)
+
+from eth_utils import (
+    is_null,
+    keccak,
+    decode_hex,
+    encode_hex,
+)
+
+from web3.providers import (
+    BaseProvider,
+)
+
+from eth_tester.exceptions import (
+    BlockNotFound,
+    FilterNotFound,
+    TransactionNotFound,
+    ValidationError,
+)
+
+from eth_tester.utils.formatting import (
+    apply_formatter_if,
+)
+
+from .middleware import (
+    ethereum_tester_middleware,
+    ethereum_tester_fixture_middleware,
+)
+
+
+def not_implemented(*args, **kwargs):
+    raise NotImplementedError("RPC method not implemented")
+
+
+@curry
+def call_eth_tester(fn_name, eth_tester, fn_args, fn_kwargs=None):
+    if fn_kwargs is None:
+        fn_kwargs = {}
+    return getattr(eth_tester, fn_name)(*fn_args, **fn_kwargs)
+
+
+def without_eth_tester(fn):
+    # workaround for: https://github.com/pytoolz/cytoolz/issues/103
+    # @functools.wraps(fn)
+    def inner(eth_tester, params):
+        return fn(params)
+    return inner
+
+
+def without_params(fn):
+    # workaround for: https://github.com/pytoolz/cytoolz/issues/103
+    # @functools.wraps(fn)
+    def inner(eth_tester, params):
+        return fn(eth_tester)
+    return inner
+
+
+@curry
+def preprocess_params(eth_tester, params, preprocessor_fn):
+    return eth_tester, preprocessor_fn(params)
+
+
+def static_return(value):
+    def inner(*args, **kwargs):
+        return value
+    return inner
+
+
+def client_version(eth_tester, params):
+    # TODO: account for the backend that is in use.
+    from eth_tester import __version__
+    return "EthereumTester/{version}/{platform}/python{v.major}.{v.minor}.{v.micro}".format(
+        version=__version__,
+        v=sys.version_info,
+        platform=sys.platform,
+    )
+
+
+@curry
+def null_if_excepts(exc_type, fn):
+    return excepts(
+        exc_type,
+        fn,
+        static_return(None),
+    )
+
+
+null_if_block_not_found = null_if_excepts(BlockNotFound)
+null_if_transaction_not_found = null_if_excepts(TransactionNotFound)
+null_if_filter_not_found = null_if_excepts(FilterNotFound)
+null_if_indexerror = null_if_excepts(IndexError)
+
+
+@null_if_indexerror
+@null_if_block_not_found
+def get_transaction_by_block_hash_and_index(eth_tester, params):
+    block_hash, transaction_index = params
+    block = eth_tester.get_block_by_hash(block_hash, full_transactions=True)
+    transaction = block['transactions'][transaction_index]
+    return transaction
+
+
+@null_if_indexerror
+@null_if_block_not_found
+def get_transaction_by_block_number_and_index(eth_tester, params):
+    block_number, transaction_index = params
+    block = eth_tester.get_block_by_number(block_number, full_transactions=True)
+    transaction = block['transactions'][transaction_index]
+    return transaction
+
+
+def create_log_filter(eth_tester, params):
+    filter_params = params[0]
+    filter_id = eth_tester.create_log_filter(**filter_params)
+    return filter_id
+
+
+def _generate_random_private_key():
+    """
+    WARNING: This is not a secure way to generate private keys and should only
+    be used for testing purposes.
+    """
+    return encode_hex(bytes(bytearray((
+        random.randint(0, 255)
+        for _ in range(32)
+    ))))
+
+
+@without_params
+def create_new_account(eth_tester):
+    return eth_tester.add_account(_generate_random_private_key())
+
+
+def personal_send_transaction(eth_tester, params):
+    transaction, password = params
+
+    try:
+        eth_tester.unlock_account(transaction['from'], password)
+        transaction_hash = eth_tester.send_transaction(transaction)
+    finally:
+        eth_tester.lock_account(transaction['from'])
+
+    return transaction_hash
+
+
+API_ENDPOINTS = {
+    'web3': {
+        'clientVersion': client_version,
+        'sha3': compose(
+            encode_hex,
+            keccak,
+            decode_hex,
+            without_eth_tester(operator.itemgetter(0)),
+        ),
+    },
+    'net': {
+        'version': not_implemented,
+        'peerCount': not_implemented,
+        'listening': not_implemented,
+    },
+    'eth': {
+        'protocolVersion': not_implemented,
+        'syncing': not_implemented,
+        'coinbase': compose(
+            operator.itemgetter(0),
+            call_eth_tester('get_accounts'),
+        ),
+        'mining': not_implemented,
+        'hashrate': not_implemented,
+        'gasPrice': not_implemented,
+        'accounts': call_eth_tester('get_accounts'),
+        'blockNumber': compose(
+            operator.itemgetter('number'),
+            call_eth_tester('get_block_by_number', fn_kwargs={'block_number': 'latest'}),
+        ),
+        'getBalance': call_eth_tester('get_balance'),
+        'getStorageAt': not_implemented,
+        'getTransactionCount': call_eth_tester('get_nonce'),
+        'getBlockTransactionCountByHash': null_if_block_not_found(compose(
+            len,
+            operator.itemgetter('transactions'),
+            call_eth_tester('get_block_by_hash'),
+        )),
+        'getBlockTransactionCountByNumber': null_if_block_not_found(compose(
+            len,
+            operator.itemgetter('transactions'),
+            call_eth_tester('get_block_by_number'),
+        )),
+        'getUncleCountByBlockHash': null_if_block_not_found(compose(
+            len,
+            operator.itemgetter('uncles'),
+            call_eth_tester('get_block_by_hash'),
+        )),
+        'getUncleCountByBlockNumber': null_if_block_not_found(compose(
+            len,
+            operator.itemgetter('uncles'),
+            call_eth_tester('get_block_by_number'),
+        )),
+        'getCode': call_eth_tester('get_code'),
+        'sign': not_implemented,
+        'sendTransaction': call_eth_tester('send_transaction'),
+        'sendRawTransaction': not_implemented,
+        'call': call_eth_tester('call'),  # TODO: untested
+        'estimateGas': call_eth_tester('estimate_gas'),  # TODO: untested
+        'getBlockByHash': null_if_block_not_found(call_eth_tester('get_block_by_hash')),
+        'getBlockByNumber': null_if_block_not_found(call_eth_tester('get_block_by_number')),
+        'getTransactionByHash': null_if_transaction_not_found(
+            call_eth_tester('get_transaction_by_hash')
+        ),
+        'getTransactionByBlockHashAndIndex': get_transaction_by_block_hash_and_index,
+        'getTransactionByBlockNumberAndIndex': get_transaction_by_block_number_and_index,
+        'getTransactionReceipt': null_if_transaction_not_found(compose(
+            apply_formatter_if(
+                static_return(None),
+                compose(is_null, operator.itemgetter('block_number')),
+            ),
+            call_eth_tester('get_transaction_receipt'),
+        )),
+        'getUncleByBlockHashAndIndex': not_implemented,
+        'getUncleByBlockNumberAndIndex': not_implemented,
+        'getCompilers': not_implemented,
+        'compileLLL': not_implemented,
+        'compileSolidity': not_implemented,
+        'compileSerpent': not_implemented,
+        'newFilter': create_log_filter,
+        'newBlockFilter': call_eth_tester('create_block_filter'),
+        'newPendingTransactionFilter': call_eth_tester('create_pending_transaction_filter'),
+        'uninstallFilter': excepts(
+            FilterNotFound,
+            compose(
+                is_null,
+                call_eth_tester('delete_filter'),
+            ),
+            static_return(False),
+        ),
+        'getFilterChanges': null_if_filter_not_found(call_eth_tester('get_only_filter_changes')),
+        'getFilterLogs': null_if_filter_not_found(call_eth_tester('get_all_filter_logs')),
+        'getLogs': not_implemented,
+        'getWork': not_implemented,
+        'submitWork': not_implemented,
+        'submitHashrate': not_implemented,
+    },
+    'db': {
+        'putString': not_implemented,
+        'getString': not_implemented,
+        'putHex': not_implemented,
+        'getHex': not_implemented,
+    },
+    'shh': {
+        'post': not_implemented,
+        'version': not_implemented,
+        'newIdentity': not_implemented,
+        'hasIdentity': not_implemented,
+        'newGroup': not_implemented,
+        'addToGroup': not_implemented,
+        'newFilter': not_implemented,
+        'uninstallFilter': not_implemented,
+        'getFilterChanges': not_implemented,
+        'getMessages': not_implemented,
+    },
+    'admin': {
+        'addPeer': not_implemented,
+        'datadir': not_implemented,
+        'nodeInfo': not_implemented,
+        'peers': not_implemented,
+        'setSolc': not_implemented,
+        'startRPC': not_implemented,
+        'startWS': not_implemented,
+        'stopRPC': not_implemented,
+        'stopWS': not_implemented,
+    },
+    'debug': {
+        'backtraceAt': not_implemented,
+        'blockProfile': not_implemented,
+        'cpuProfile': not_implemented,
+        'dumpBlock': not_implemented,
+        'gtStats': not_implemented,
+        'getBlockRLP': not_implemented,
+        'goTrace': not_implemented,
+        'memStats': not_implemented,
+        'seedHashSign': not_implemented,
+        'setBlockProfileRate': not_implemented,
+        'setHead': not_implemented,
+        'stacks': not_implemented,
+        'startCPUProfile': not_implemented,
+        'startGoTrace': not_implemented,
+        'stopCPUProfile': not_implemented,
+        'stopGoTrace': not_implemented,
+        'traceBlock': not_implemented,
+        'traceBlockByNumber': not_implemented,
+        'traceBlockByHash': not_implemented,
+        'traceBlockFromFile': not_implemented,
+        'traceTransaction': not_implemented,
+        'verbosity': not_implemented,
+        'vmodule': not_implemented,
+        'writeBlockProfile': not_implemented,
+        'writeMemProfile': not_implemented,
+    },
+    'miner': {
+        'makeDAG': not_implemented,
+        'setExtra': not_implemented,
+        'setGasPrice': not_implemented,
+        'start': not_implemented,
+        'startAutoDAG': not_implemented,
+        'stop': not_implemented,
+        'stopAutoDAG': not_implemented,
+    },
+    'personal': {
+        'ecRecover': not_implemented,
+        'importRawKey': call_eth_tester('add_account'),
+        'listAccounts': call_eth_tester('get_accounts'),
+        'lockAccount': excepts(
+            ValidationError,
+            compose(static_return(True), call_eth_tester('lock_account')),
+            static_return(False),
+        ),
+        'newAccount': create_new_account,
+        'unlockAccount': excepts(
+            ValidationError,
+            compose(static_return(True), call_eth_tester('unlock_account')),
+            static_return(False),
+        ),
+        'sendTransaction': personal_send_transaction,
+        'sign': not_implemented,
+    },
+    'txpool': {
+        'content': not_implemented,
+        'inspect': not_implemented,
+        'status': not_implemented,
+    },
+    'evm': {
+        'mine': call_eth_tester('mine_blocks'),
+    },
+}
+
+
+class EthereumTesterProvider(BaseProvider):
+    middlewares = [
+        ethereum_tester_fixture_middleware,
+        ethereum_tester_middleware,
+    ]
+    ethereum_tester = None
+    api_endpoints = None
+
+    def __init__(self, ethereum_tester, api_endpoints=API_ENDPOINTS):
+        self.ethereum_tester = ethereum_tester
+        self.api_endpoints = api_endpoints
+
+    def make_request(self, method, params):
+        namespace, _, endpoint = method.partition('_')
+        try:
+            delegator = self.api_endpoints[namespace][endpoint]
+        except KeyError:
+            return {
+                "error": "Unknown RPC Endpoint: {0}".format(method),
+            }
+
+        try:
+            response = delegator(self.ethereum_tester, params)
+        except NotImplementedError:
+            return {
+                "error": "RPC Endpoint has not been implemented: {0}".format(method),
+            }
+        else:
+            return {
+                'result': response,
+            }
+
+    def isConnected(self):
+        return True

--- a/web3/providers/eth_tester/middleware.py
+++ b/web3/providers/eth_tester/middleware.py
@@ -1,0 +1,185 @@
+from __future__ import absolute_import
+
+import operator
+
+from cytoolz.functoolz import (
+    complement,
+    compose,
+    partial,
+    identity,
+)
+
+from eth_utils import (
+    is_dict,
+    is_string,
+)
+
+from web3.middleware import (
+    construct_formatting_middleware,
+    construct_fixture_middleware,
+)
+
+from web3.utils.formatters import (
+    apply_formatter_if,
+    apply_formatters_to_args,
+    apply_formatters_to_dict,
+    apply_key_map,
+    hex_to_integer,
+    integer_to_hex,
+    static_return,
+)
+
+
+def is_named_block(value):
+    return value in {"latest", "earliest", "pending"}
+
+
+to_integer_if_hex = apply_formatter_if(hex_to_integer, is_string)
+
+
+is_not_named_block = complement(is_named_block)
+
+
+TRANSACTION_KEY_MAPPINGS = {
+    'block_hash': 'blockHash',
+    'block_number': 'blockNumber',
+    'gas_price': 'gasPrice',
+    'transaction_hash': 'transactionHash',
+    'transaction_index': 'transactionIndex',
+}
+
+transaction_key_remapper = apply_key_map(TRANSACTION_KEY_MAPPINGS)
+
+
+RECEIPT_KEY_MAPPINGS = {
+    'block_hash': 'blockHash',
+    'block_number': 'blockNumber',
+    'contract_address': 'contractAddress',
+    'gas_price': 'gasPrice',
+    'transaction_hash': 'transactionHash',
+    'transaction_index': 'transactionIndex',
+}
+
+
+receipt_key_remapper = apply_key_map(RECEIPT_KEY_MAPPINGS)
+
+
+BLOCK_KEY_MAPPINGS = {
+    'gas_limit': 'gasLimit',
+    'sha3_uncles': 'sha3Uncles',
+    'transactions_root': 'transactionsRoot',
+}
+
+
+block_key_remapper = apply_key_map(BLOCK_KEY_MAPPINGS)
+
+
+TRANSACTION_PARAMS_MAPPING = {
+    'gasPrice': 'gas_price',
+}
+
+
+transaction_params_remapper = apply_key_map(TRANSACTION_PARAMS_MAPPING)
+
+
+TRANSACTION_PARAMS_FORMATTERS = {
+    'gas': to_integer_if_hex,
+    'gasPrice': to_integer_if_hex,
+    'value': to_integer_if_hex,
+}
+
+
+transaction_params_formatter = apply_formatters_to_dict(TRANSACTION_PARAMS_FORMATTERS)
+
+
+TRANSACTION_FORMATTERS = {
+    'to': apply_formatter_if(static_return(None), partial(operator.eq, b'')),
+}
+
+
+transaction_formatter = apply_formatters_to_dict(TRANSACTION_FORMATTERS)
+
+
+ethereum_tester_middleware = construct_formatting_middleware(
+    request_formatters={
+        # Eth
+        'eth_getBlockByNumber': apply_formatters_to_args(
+            apply_formatter_if(to_integer_if_hex, is_not_named_block),
+        ),
+        'eth_getFilterChanges': apply_formatters_to_args(hex_to_integer),
+        'eth_getFilterLogs': apply_formatters_to_args(hex_to_integer),
+        'eth_getBlockTransactionCountByNumber': apply_formatters_to_args(
+            apply_formatter_if(to_integer_if_hex, is_not_named_block),
+        ),
+        'eth_getUncleCountByBlockNumber': apply_formatters_to_args(
+            apply_formatter_if(to_integer_if_hex, is_not_named_block),
+        ),
+        'eth_getTransactionByBlockHashAndIndex': apply_formatters_to_args(
+            identity,
+            to_integer_if_hex,
+        ),
+        'eth_getTransactionByBlockNumberAndIndex': apply_formatters_to_args(
+            apply_formatter_if(to_integer_if_hex, is_not_named_block),
+            to_integer_if_hex,
+        ),
+        'eth_getUncleByBlockNumberAndIndex': apply_formatters_to_args(
+            apply_formatter_if(to_integer_if_hex, is_not_named_block),
+            to_integer_if_hex,
+        ),
+        'eth_sendTransaction': apply_formatters_to_args(
+            transaction_params_formatter,
+        ),
+        'eth_estimateGas': apply_formatters_to_args(
+            transaction_params_formatter,
+        ),
+        'eth_call': apply_formatters_to_args(
+            transaction_params_formatter,
+        ),
+        'eth_uninstallFilter': apply_formatters_to_args(hex_to_integer),
+        # Personal
+        'personal_sendTransaction': apply_formatters_to_args(
+            compose(transaction_params_remapper, transaction_params_formatter),
+            identity,
+        ),
+    },
+    result_formatters={
+        'eth_getBlockByHash': apply_formatter_if(
+            block_key_remapper,
+            is_dict,
+        ),
+        'eth_getBlockByNumber': apply_formatter_if(
+            block_key_remapper,
+            is_dict,
+        ),
+        'eth_getBlockTransactionCountByHash': apply_formatter_if(
+            transaction_key_remapper,
+            is_dict,
+        ),
+        'eth_getBlockTransactionCountByNumber': apply_formatter_if(
+            transaction_key_remapper,
+            is_dict,
+        ),
+        'eth_getTransactionByHash': apply_formatter_if(
+            compose(transaction_key_remapper, transaction_formatter),
+            is_dict,
+        ),
+        'eth_getTransactionReceipt': apply_formatter_if(receipt_key_remapper, is_dict),
+        'eth_newFilter': integer_to_hex,
+        'eth_newBlockFilter': integer_to_hex,
+        'eth_newPendingTransactionFilter': integer_to_hex,
+    },
+)
+
+
+ethereum_tester_fixture_middleware = construct_fixture_middleware({
+    # Eth
+    'eth_protocolVersion': '63',
+    'eth_hashrate': 0,
+    'eth_gasPrice': 1,
+    'eth_syncing': False,
+    'eth_mining': False,
+    # Net
+    'net_version': '12345',
+    'net_listening': False,
+    'net_peerCount': 0,
+})

--- a/web3/utils/formatters.py
+++ b/web3/utils/formatters.py
@@ -8,6 +8,7 @@ import sys
 
 from cytoolz.functoolz import (
     curry,
+    compose,
 )
 
 from eth_utils import (
@@ -45,6 +46,14 @@ def apply_formatter_at_index(formatter, at_index, value):
             yield formatter(item)
         else:
             yield item
+
+
+def apply_formatters_to_args(*formatters):
+    return compose(*(
+        apply_formatter_at_index(formatter, index)
+        for index, formatter
+        in enumerate(formatters)
+    ))
 
 
 @curry
@@ -119,3 +128,13 @@ def static_result(value):
     def inner(*args, **kwargs):
         return {'result': value}
     return inner
+
+
+@curry
+@to_dict
+def apply_key_map(key_mappings, value):
+    for key, item in value.items():
+        if key in key_mappings:
+            yield key_mappings[key], item
+        else:
+            yield key, item


### PR DESCRIPTION
### What was wrong?

Get started integrating the `ethereum-tester` library into the integration tests.

### How was it fixed?

* Implementing a new provider that is dependent on the `ethereum-tester` library being installed.
* Implement a few middlewares for that provider to get everything normalized to web3 expectations.

#### Cute Animal Picture

![Cute animal picture]()
