### PR TITLE
Made it clear that you can pass `nonce` to `transact()`

### DIFF
--- a/web3/contract.py
+++ b/web3/contract.py
@@ -541,7 +541,7 @@ class Contract(object):
         be available once the transaction has been mined.
 
         :param transaction: Dictionary of transaction info for web3 interface.
-        Variables include ``from``, ``gas``, ``value``, ``gasPrice``.
+        Variables include ``from``, ``gas``, ``value``, ``gasPrice``, ``nonce``.
 
         :return: ``Transactor`` object that has contract
             public functions exposed as Python methods.


### PR DESCRIPTION
Made it clear in the docstring, that a custom `nonce` can be passed when invoking transactions via `transact()`.

### What was wrong?

The docstring wasn't accutate. It didn't mention that a custom `nonce` can be passed to `transact()`.

### How was it fixed?

The docstring has been amended to be accurate ;)

#### Cute Animal Picture

![Cute animal picture](http://amazinganimalstories.com/wp-content/uploads/2013/09/cute3.jpg)
