### PR TITLE
bigfix: fixture-middleware

### DIFF
--- a/tests/core/middleware/test_fixture_middleware.py
+++ b/tests/core/middleware/test_fixture_middleware.py
@@ -1,5 +1,9 @@
 import pytest
 
+from eth_utils import (
+    is_dict,
+)
+
 from web3.middleware import (
     construct_fixture_middleware,
 )
@@ -11,7 +15,7 @@ FIXTURES = {
 
 
 def _make_request(method, params):
-    return 'default'
+    return {'result': 'default'}
 
 
 @pytest.mark.parametrize(
@@ -25,4 +29,6 @@ def test_fixture_middleware(method, params, expected):
     middleware = construct_fixture_middleware(FIXTURES)(_make_request, None)
 
     actual = middleware(method, params)
-    assert actual == expected
+    assert is_dict(actual)
+    assert 'result' in actual
+    assert actual['result'] == expected

--- a/web3/middleware/fixture.py
+++ b/web3/middleware/fixture.py
@@ -6,7 +6,9 @@ def construct_fixture_middleware(fixtures):
     def fixture_middleware(make_request, web3):
         def middleware(method, params):
             if method in fixtures:
-                return fixtures[method]
+                return {
+                    'result': fixtures[method],
+                }
             else:
                 return make_request(method, params)
         return middleware


### PR DESCRIPTION
### What was wrong?

Fixture middleware needed to return an actual dictionary with a `'result'` key to be useful.

### How was it fixed?

Changed it to return a dictionary.

#### Cute Animal Picture

![poachedbabyrhino](https://user-images.githubusercontent.com/824194/30224623-b1392ec8-948c-11e7-9e4f-541ed3c39ff9.jpg)

