### PR TITLE
standalone: unicode_literals

### DIFF
--- a/web3/eth.py
+++ b/web3/eth.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from cytoolz.dicttoolz import (
     assoc,
 )

--- a/web3/middleware/stalecheck.py
+++ b/web3/middleware/stalecheck.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import time
 
 from web3.exceptions import StaleBlockchain

--- a/web3/utils/blocks.py
+++ b/web3/utils/blocks.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from eth_utils import (
     is_hex,
     is_string,

--- a/web3/utils/module_testing/eth_module.py
+++ b/web3/utils/module_testing/eth_module.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from eth_abi import (
     decode_single,
 )

--- a/web3/utils/module_testing/personal_module.py
+++ b/web3/utils/module_testing/personal_module.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from eth_utils import (
     is_address,
     is_list_like,


### PR DESCRIPTION
### What was wrong?

There were a few places that needed `__future__` imports of `unicode_literals`.

### How was it fixed?

Added them

#### Cute Animal Picture

![rhino-n-baby-openin-pic-for-ro](https://user-images.githubusercontent.com/824194/30224657-d2a4c216-948c-11e7-99de-8448583f1b34.jpg)
