### PR TITLE
standalone: rename ethtestrpc module tests

### DIFF
--- a/tests/integration/test_ethtestrpc.py
+++ b/tests/integration/test_ethtestrpc.py
@@ -119,7 +119,7 @@ def funded_account_for_raw_txn(web3):
     return account
 
 
-class TestEthereumTesterWeb3Module(Web3ModuleTest):
+class TestEthTestRPCWeb3Module(Web3ModuleTest):
     def _check_web3_clientVersion(self, client_version):
         assert client_version.startswith('TestRPC/')
 
@@ -136,7 +136,7 @@ def not_implemented(method, exc_type=AttributeError):
     return inner
 
 
-class TestEthereumTesterEthModule(EthModuleTest):
+class TestEthTestRPCEthModule(EthModuleTest):
     #
     # Eth-Testrpc doesn't comply with RPC spec in many ways.
     #
@@ -191,15 +191,15 @@ class TestEthereumTesterEthModule(EthModuleTest):
     )
 
 
-class TestEthereumTesterVersionModule(VersionModuleTest):
+class TestEthTestRPCVersionModule(VersionModuleTest):
     pass
 
 
-class TestEthereumTesterNetModule(NetModuleTest):
+class TestEthTestRPCNetModule(NetModuleTest):
     pass
 
 
-class TestEthereumTesterPersonalModule(PersonalModuleTest):
+class TestEthTestRPCPersonalModule(PersonalModuleTest):
     test_personal_sign_and_ecrecover = not_implemented(
         PersonalModuleTest.test_personal_sign_and_ecrecover,
     )


### PR DESCRIPTION
### What was wrong?

The incoming `ethereum-tester` integration collided with the names used in the existing testrpc tests.

### How was it fixed?

Renamed them from `EthereumTester` to `EthTestRPC`

#### Cute Animal Picture

![2dakbrl123456large](https://user-images.githubusercontent.com/824194/30224700-fce41cac-948c-11e7-9de8-c38d4d14c1b7.jpg)

