### PR TITLE
stand-alone: CI testing version upgrades

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,9 @@
-pytest>=2.8.2
+pytest>=3.2.1
 pytest-pythonpath>=0.3
 tox>=1.8.0
 eth-testrpc>=1.2.0
 ethereum>=1.6.1,<2.0
 hypothesis>=3.4.2
 flaky>=3.3.0
-flake8==3.0.4
+flake8==3.4.1
 py-geth==1.10.0


### PR DESCRIPTION
### What was wrong?

My local version of `pytest` was old and we're using some features only available in the `3.2.x` line.  Same with `flake8` having new things it identifies.

### How was it fixed?

Bumped the versions.

#### Cute Animal Picture

![baby-rhino-rhinos-20108363-470-579](https://user-images.githubusercontent.com/824194/30224742-2c489cac-948d-11e7-849b-749cd80d4369.jpg)
