### PR TITLE
Adding toBytes, with same functionality as toAscii

### DIFF
--- a/tests/core/shh-module/test_shh_filter.py
+++ b/tests/core/shh-module/test_shh_filter.py
@@ -4,24 +4,25 @@ from web3.utils.compat import sleep
 def test_shh_filter(web3, skip_if_testrpc):
     skip_if_testrpc(web3)
     recieved_messages = []
-    shh_filter = web3.shh.filter({"topics": [web3.fromAscii("test")]})
+    topic = web3.toHex(text="test")
+    shh_filter = web3.shh.filter({"topics": [topic]})
     shh_filter.watch(recieved_messages.append)
 
     payloads = []
     payloads.append(str.encode("payload1"))
     web3.shh.post({
-        "topics": [web3.fromAscii("test")],
-        "payload": web3.fromAscii(payloads[len(payloads) - 1]),
+        "topics": [topic],
+        "payload": web3.toHex(text=payloads[-1]),
     })
     sleep(1)
 
     payloads.append(str.encode("payload2"))
     web3.shh.post({
-        "topics": [web3.fromAscii("test")],
-        "payload": web3.fromAscii(payloads[len(payloads) - 1]),
+        "topics": [topic],
+        "payload": web3.toHex(text=payloads[-1]),
     })
     sleep(1)
     assert len(recieved_messages) > 1
 
     for message in recieved_messages:
-        assert web3.toAscii(message["payload"]) in payloads
+        assert web3.toBytes(message["payload"]) in payloads

--- a/tests/core/shh-module/test_shh_post.py
+++ b/tests/core/shh-module/test_shh_post.py
@@ -2,6 +2,6 @@ def test_shh_post(web3, skip_if_testrpc):
     skip_if_testrpc(web3)
     random_topic = "testing"
     assert web3.shh.post({
-        "topics": [web3.fromAscii(random_topic)],
-        "payload": web3.fromAscii("testing shh on web3.py"),
+        "topics": [web3.toHex(text=random_topic)],
+        "payload": web3.toHex(text="testing shh on web3.py"),
     })

--- a/tests/core/utilities/test_encoding.py
+++ b/tests/core/utilities/test_encoding.py
@@ -9,7 +9,6 @@ from hypothesis import (
 )
 
 from web3.utils.encoding import (
-    from_decimal,
     hex_encode_abi_type,
     to_decimal,
     to_hex,
@@ -20,30 +19,21 @@ from web3.utils.encoding import (
     "value,expected",
     [
         (1, '0x1'),
-        ('1', '0x1'),
         (15, '0xf'),
-        ('15', '0xf'),
         (-1, '-0x1'),
-        ('-1', '-0x1'),
         (-15, '-0xf'),
-        ('-15', '-0xf'),
         (0, '0x0'),
-        ('0', '0x0'),
         (-0, '0x0'),
-        ('-0', '0x0'),
-        ("0x0", "0x0"),
-        ("-0x0", "0x0"),
-        ("0x5", "0x5"),
     ]
 )
-def test_from_decimal(value, expected):
-    assert from_decimal(value) == expected
+def test_to_hex(value, expected):
+    assert to_hex(value) == expected
 
 
 @given(value=st.integers(min_value=-1 * 2**255 + 1, max_value=2**256 - 1))
-def test_conversion_rount_trip(value):
-    intermediate_value = from_decimal(value)
-    result_value = to_decimal(intermediate_value)
+def test_conversion_round_trip(value):
+    intermediate_value = to_hex(value)
+    result_value = to_decimal(hexstr=intermediate_value)
     error_msg = "Expected: {0!r}, Result: {1!r}, Intermediate: {2!r}".format(
         value,
         result_value,

--- a/tests/core/web3-module/test_conversions.py
+++ b/tests/core/web3-module/test_conversions.py
@@ -15,14 +15,12 @@ from web3 import Web3
         (0xFF, b'\xff'),
         (0, b'\x00'),
         (256, b'\x01\x00'),
+        (True, b'\x01'),
+        (False, b'\x00'),
     )
 )
 def test_to_bytes_primitive(val, expected):
-    if sys.version_info.major < 3:
-        with pytest.raises(NotImplementedError):
-            Web3.toBytes(val)
-    else:
-        assert Web3.toBytes(val) == expected
+    assert Web3.toBytes(val) == expected
 
 
 @pytest.mark.parametrize(
@@ -39,11 +37,7 @@ def test_to_bytes_primitive(val, expected):
     )
 )
 def test_to_bytes_hexstr(val, expected):
-    if sys.version_info.major < 3:
-        with pytest.raises(NotImplementedError):
-            Web3.toBytes(hexstr=val)
-    else:
-        assert Web3.toBytes(hexstr=val) == expected
+    assert Web3.toBytes(hexstr=val) == expected
 
 
 @pytest.mark.parametrize(
@@ -54,11 +48,7 @@ def test_to_bytes_hexstr(val, expected):
     )
 )
 def test_to_bytes_text(val, expected):
-    if sys.version_info.major < 3:
-        with pytest.raises(NotImplementedError):
-            Web3.toBytes(text=val)
-    else:
-        assert Web3.toBytes(text=val) == expected
+    assert Web3.toBytes(text=val) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/core/web3-module/test_conversions.py
+++ b/tests/core/web3-module/test_conversions.py
@@ -31,6 +31,8 @@ def test_to_bytes_primitive(val, expected):
         ('0x', b''),
         ('0x0', b'\x00'),
         ('0x1', b'\x01'),
+        ('0', b'\x00'),
+        ('1', b'\x01'),
         ('0xFF', b'\xff'),
         ('0x100', b'\x01\x00'),
         ('0x0000', b'\x00\x00'),

--- a/tests/core/web3-module/test_conversions.py
+++ b/tests/core/web3-module/test_conversions.py
@@ -67,3 +67,43 @@ def test_to_text(val, expected):
             Web3.toText(val)
     else:
         assert Web3.toText(val) == expected
+
+
+@pytest.mark.parametrize(
+    'val, expected',
+    (
+        (b'\x00', 0),
+        (b'\x01', 1),
+        (b'\x00\x01', 1),
+        (b'\x01\x00', 256),
+        ('255', 255),
+        (True, 1),
+        (False, 0),
+        # Deprecated:
+        ('0x0', 0),
+        ('0x1', 1),
+        ('0x01', 1),
+        ('0x10', 16),
+    )
+)
+def test_to_decimal(val, expected):
+    if isinstance(val, bytes) and bytes == str:
+        pytest.skip("Python 3 is required to pass in bytes")
+    assert Web3.toDecimal(val) == expected
+
+
+@pytest.mark.parametrize(
+    'val, expected',
+    (
+        ('0x0', 0),
+        ('0x1', 1),
+        ('0x01', 1),
+        ('0x10', 16),
+        ('0', 0),
+        ('1', 1),
+        ('01', 1),
+        ('10', 16),
+    )
+)
+def test_to_decimal_hexstr(val, expected):
+    assert Web3.toDecimal(hexstr=val) == expected

--- a/tests/core/web3-module/test_conversions.py
+++ b/tests/core/web3-module/test_conversions.py
@@ -1,0 +1,77 @@
+# coding=utf-8
+
+from __future__ import unicode_literals
+
+import pytest
+import sys
+
+from web3 import Web3
+
+
+@pytest.mark.parametrize(
+    'val, expected',
+    (
+        (0x01, b'\x01'),
+        (0xFF, b'\xff'),
+        (0, b'\x00'),
+        (256, b'\x01\x00'),
+    )
+)
+def test_to_bytes_primitive(val, expected):
+    if sys.version_info.major < 3:
+        with pytest.raises(NotImplementedError):
+            Web3.toBytes(val)
+    else:
+        assert Web3.toBytes(val) == expected
+
+
+@pytest.mark.parametrize(
+    'val, expected',
+    (
+        ('0x', b''),
+        ('0x0', b'\x00'),
+        ('0x1', b'\x01'),
+        ('0xFF', b'\xff'),
+        ('0x100', b'\x01\x00'),
+        ('0x0000', b'\x00\x00'),
+    )
+)
+def test_to_bytes_hexstr(val, expected):
+    if sys.version_info.major < 3:
+        with pytest.raises(NotImplementedError):
+            Web3.toBytes(hexstr=val)
+    else:
+        assert Web3.toBytes(hexstr=val) == expected
+
+
+@pytest.mark.parametrize(
+    'val, expected',
+    (
+        ('cowmö', b'cowm\xc3\xb6'),
+        ('', b''),
+    )
+)
+def test_to_bytes_text(val, expected):
+    if sys.version_info.major < 3:
+        with pytest.raises(NotImplementedError):
+            Web3.toBytes(text=val)
+    else:
+        assert Web3.toBytes(text=val) == expected
+
+
+@pytest.mark.parametrize(
+    'val, expected',
+    (
+        (b'', ''),
+        ('0x', ''),
+        (b'cowm\xc3\xb6', 'cowmö'),
+        ('0x636f776dc3b6', 'cowmö'),
+        (0x636f776dc3b6, 'cowmö'),
+    )
+)
+def test_to_text(val, expected):
+    if sys.version_info.major < 3:
+        with pytest.raises(NotImplementedError):
+            Web3.toText(val)
+    else:
+        assert Web3.toText(val) == expected

--- a/web3/main.py
+++ b/web3/main.py
@@ -50,10 +50,12 @@ from web3.utils.decorators import (
     deprecated_for,
 )
 from web3.utils.encoding import (
-    hex_encode_abi_type,
-    to_hex,
-    to_decimal,
     from_decimal,
+    hex_encode_abi_type,
+    to_bytes,
+    to_decimal,
+    to_hex,
+    to_text,
 )
 
 
@@ -88,8 +90,10 @@ class Web3(object):
     Iban = Iban
 
     # Encoding and Decoding
-    toHex = staticmethod(to_hex)
+    toBytes = staticmethod(to_bytes)
     toDecimal = staticmethod(to_decimal)
+    toHex = staticmethod(to_hex)
+    toText = staticmethod(to_text)
     fromDecimal = staticmethod(from_decimal)
 
     # Currency Utility
@@ -222,43 +226,6 @@ class Web3(object):
                 return True
         else:
             return False
-
-    @classmethod
-    def toBytes(cls, primitive=None, hexstr=None, text=None):
-        if bytes is str:
-            raise NotImplementedError("This method only works in Python 3+.")
-
-        args = (arg for arg in (primitive, text, hexstr) if arg is not None)
-        if len(list(args)) != 1:
-            raise TypeError(
-                "Only supply one positional arg, or the text, or hexstr keyword args. "
-                "You supplied %r and %r" % (primitive, {'text': text, 'hexstr': hexstr})
-            )
-
-        if isinstance(primitive, bytes):
-            return primitive
-        elif isinstance(primitive, int):
-            return cls.toBytes(hexstr=hex(primitive))
-        elif hexstr is not None:
-            if len(hexstr) % 2:
-                hexstr = '0x0' + hexstr[2:]
-            return decode_hex(hexstr)
-        elif text is not None:
-            return text.encode('utf-8')
-        raise TypeError("expected an int in first arg, or keyword of hexstr or text")
-
-    @classmethod
-    def toText(cls, val):
-        if bytes is str:
-            raise NotImplementedError("This method only works in Python 3+.")
-
-        if isinstance(val, str):
-            return decode_hex(val).decode('utf-8')
-        elif isinstance(val, bytes):
-            return val.decode('utf-8')
-        elif isinstance(val, int):
-            return cls.toText(hex(val))
-        raise TypeError("Expected an int, bytes or hexstr.")
 
     @staticmethod
     @deprecated_for("toBytes()")

--- a/web3/main.py
+++ b/web3/main.py
@@ -90,9 +90,11 @@ class Web3(object):
 
     # Encoding and Decoding
     toHex = staticmethod(to_hex)
-    toAscii = staticmethod(decode_hex)
+    toBytes = staticmethod(decode_hex)
+    toAscii = toBytes
     toUtf8 = staticmethod(compose(force_text, decode_hex))
-    fromAscii = staticmethod(encode_hex)
+    fromBytes = staticmethod(encode_hex)
+    fromAscii = fromBytes
     fromUtf8 = staticmethod(encode_hex)
     toDecimal = staticmethod(to_decimal)
     fromDecimal = staticmethod(from_decimal)

--- a/web3/main.py
+++ b/web3/main.py
@@ -94,7 +94,6 @@ class Web3(object):
     toDecimal = staticmethod(to_decimal)
     toHex = staticmethod(to_hex)
     toText = staticmethod(to_text)
-    fromDecimal = staticmethod(from_decimal)
 
     # Currency Utility
     toWei = staticmethod(to_wei)
@@ -170,19 +169,13 @@ class Web3(object):
                 "You supplied %r and %r" % (primitive, {'text': text, 'hexstr': hexstr})
             )
 
-        if isinstance(primitive, bytes):
-            if bytes == str:
-                # *shakes fist at python 2*
-                # fall back to deprecated functionality
-                pass
-            else:
-                return keccak(primitive)
-        elif isinstance(primitive, int):
-            return keccak(decode_hex(hex(primitive)))
-        elif text is not None:
-            return keccak(text.encode('utf-8'))
-        elif hexstr is not None:
-            return keccak(decode_hex(hexstr))
+        if isinstance(primitive, bytes) and bytes == str:
+            # *shakes fist at python 2*
+            # fall back to deprecated functionality
+            pass
+        elif isinstance(primitive, (bytes, int)) or text is not None or hexstr is not None:
+            input_bytes = to_bytes(primitive, hexstr=hexstr, text=text)
+            return keccak(input_bytes)
 
         # handle deprecated cases
         if encoding in ('hex', None):
@@ -246,3 +239,8 @@ class Web3(object):
     @deprecated_for("toHex()")
     def fromUtf8(string):
         return encode_hex(string)
+
+    @staticmethod
+    @deprecated_for("toHex()")
+    def fromDecimal(decimal):
+        return from_decimal(decimal)

--- a/web3/main.py
+++ b/web3/main.py
@@ -50,6 +50,9 @@ from web3.manager import (
     RequestManager,
 )
 
+from web3.utils.decorators import (
+    deprecated_for,
+)
 from web3.utils.encoding import (
     hex_encode_abi_type,
     to_hex,
@@ -91,10 +94,8 @@ class Web3(object):
     # Encoding and Decoding
     toHex = staticmethod(to_hex)
     toBytes = staticmethod(decode_hex)
-    toAscii = toBytes
     toUtf8 = staticmethod(compose(force_text, decode_hex))
     fromBytes = staticmethod(encode_hex)
-    fromAscii = fromBytes
     fromUtf8 = staticmethod(encode_hex)
     toDecimal = staticmethod(to_decimal)
     fromDecimal = staticmethod(from_decimal)
@@ -141,18 +142,13 @@ class Web3(object):
     def setProviders(self, providers):
         self.manager.setProvider(providers)
 
+    @deprecated_for("the `manager` attribute")
     def setManager(self, manager):
-        warnings.warn(DeprecationWarning(
-            "The `setManager` method has been deprecated.  Please update your "
-            "code to directly set the `manager` property."
-        ))
         self.manager = manager
 
     @property
+    @deprecated_for("`providers`, which is now a list")
     def currentProvider(self):
-        warnings.warn(DeprecationWarning(
-            "The `currentProvider` property has been renamed to `providers` and is now a list."
-        ))
         return self.manager.providers[0]
 
     @staticmethod
@@ -234,3 +230,13 @@ class Web3(object):
                 return True
         else:
             return False
+
+    @staticmethod
+    @deprecated_for("toBytes()")
+    def toAscii(val):
+        return decode_hex(val)
+
+    @staticmethod
+    @deprecated_for("toHex()")
+    def fromAscii(val):
+        return encode_hex(val)

--- a/web3/utils/decorators.py
+++ b/web3/utils/decorators.py
@@ -1,4 +1,5 @@
 import functools
+import warnings
 
 
 class combomethod(object):
@@ -31,3 +32,24 @@ def reject_recursive_repeats(to_wrap):
         del to_wrap.__already_called[instances]
         return wrapped_val
     return wrapped
+
+
+def deprecated_for(replace_message):
+    '''
+    Decorate a deprecated function, with info about what to use instead, like:
+    @deprecated("toBytes()")
+    def toAscii(arg):
+        ...
+    '''
+    def decorator(to_wrap):
+        @functools.wraps(to_wrap)
+        def wrapper(*args, **kwargs):
+            warnings.simplefilter('always', DeprecationWarning)
+            warnings.warn(
+                "%s is deprecated in favor of %s" % (to_wrap.__name__, replace_message),
+                category=DeprecationWarning,
+                stacklevel=2)
+            warnings.simplefilter('default', DeprecationWarning)
+            return to_wrap(*args, **kwargs)
+        return wrapper
+    return decorator

--- a/web3/utils/encoding.py
+++ b/web3/utils/encoding.py
@@ -10,7 +10,6 @@ from eth_utils import (
     is_boolean,
     is_dict,
     is_integer,
-    coerce_args_to_text,
     coerce_args_to_bytes,
     add_0x_prefix,
     is_0x_prefixed,
@@ -104,7 +103,6 @@ def pad_hex(value, bit_size):
     return add_0x_prefix(value.zfill(int(bit_size / 4)))
 
 
-@coerce_args_to_text
 def to_hex(value):
     """
     Auto converts any supported value into it's hex representation.
@@ -115,8 +113,10 @@ def to_hex(value):
     if is_dict(value):
         return encode_hex(json.dumps(value, sort_keys=True))
 
-    if is_string(value):
+    if isinstance(value, bytes):
         return encode_hex(value)
+    elif isinstance(value, str):
+        return encode_hex(value.encode('utf-8'))
 
     if is_integer(value):
         return from_decimal(value)

--- a/web3/utils/encoding.py
+++ b/web3/utils/encoding.py
@@ -32,7 +32,9 @@ from web3.utils.abi import (
     size_of_type,
     sub_type_of_array_type,
 )
-
+from web3.utils.decorators import (
+    deprecated_for,
+)
 from web3.utils.validation import (
     validate_abi_type,
     validate_abi_value,
@@ -117,11 +119,13 @@ def to_hex(value):
 
     if isinstance(value, bytes):
         return encode_hex(value)
-    elif isinstance(value, str):
+    elif is_string(value):
         return encode_hex(value.encode('utf-8'))
 
     if is_integer(value):
-        return from_decimal(value)
+        # python2 longs end up with an `L` hanging off the end of their hexidecimal
+        # representation.
+        return hex(value).rstrip('L')
 
     raise TypeError(
         "Unsupported type: '{0}'.  Must be one of Boolean, Dictionary, String, "
@@ -156,9 +160,10 @@ def to_decimal(value=None, hexstr=None):
         return int(value)
 
 
+@deprecated_for("to_hex")
 def from_decimal(value):
     """
-    Converts numeric value to it's hex representation
+    Converts numeric value to its hex representation
     """
     if is_string(value):
         if is_0x_prefixed(value) or _is_prefixed(value, '-0x'):
@@ -166,10 +171,7 @@ def from_decimal(value):
         else:
             value = int(value)
 
-    # python2 longs end up with an `L` hanging off the end of their hexidecimal
-    # representation.
-    result = hex(value).rstrip('L')
-    return result
+    return to_hex(value)
 
 
 def to_bytes(primitive=None, hexstr=None, text=None):

--- a/web3/utils/encoding.py
+++ b/web3/utils/encoding.py
@@ -1,6 +1,7 @@
 # String encodings and numeric representations
-import sys
 import json
+import sys
+import warnings
 
 from rlp.sedes import big_endian_int
 
@@ -128,19 +129,31 @@ def to_hex(value):
     )
 
 
-def to_decimal(value):
+def to_decimal(value=None, hexstr=None):
     """
     Converts value to it's decimal representation in string
     """
-    if is_string(value):
-        if is_0x_prefixed(value) or _is_prefixed(value, '-0x'):
-            value = int(value, 16)
-        else:
-            value = int(value)
-    else:
-        value = int(value)
+    if (value is None) == (hexstr is None):
+        raise TypeError(
+            "Only supply one positional argument, or the hexstr keyword, like: "
+            "toDecimal('255') or toDecimal(hexstr='FF')"
+        )
 
-    return value
+    if hexstr is not None:
+        return int(hexstr, 16)
+    elif is_string(value):
+        if bytes != str and isinstance(value, bytes):
+            return to_decimal(hexstr=to_hex(value))
+        elif is_0x_prefixed(value) or _is_prefixed(value, '-0x'):
+            warnings.warn(DeprecationWarning(
+                "Sending a hex string in the first position has been deprecated. Please use "
+                "toDecimal(hexstr='%s') instead." % value
+            ))
+            return to_decimal(hexstr=value)
+        else:
+            return int(value)
+    else:
+        return int(value)
 
 
 def from_decimal(value):

--- a/web3/utils/encoding.py
+++ b/web3/utils/encoding.py
@@ -160,9 +160,6 @@ def from_decimal(value):
 
 
 def to_bytes(primitive=None, hexstr=None, text=None):
-    if bytes is str:
-        raise NotImplementedError("This method only works in Python 3+.")
-
     args = (arg for arg in (primitive, text, hexstr) if arg is not None)
     if len(list(args)) != 1:
         raise TypeError(
@@ -170,7 +167,9 @@ def to_bytes(primitive=None, hexstr=None, text=None):
             "You supplied %r and %r" % (primitive, {'text': text, 'hexstr': hexstr})
         )
 
-    if isinstance(primitive, bytes):
+    if is_boolean(primitive):
+        return b'\x01' if primitive else b'\x00'
+    elif isinstance(primitive, bytes):
         return primitive
     elif isinstance(primitive, int):
         return to_bytes(hexstr=hex(primitive))
@@ -185,6 +184,7 @@ def to_bytes(primitive=None, hexstr=None, text=None):
 
 def to_text(val):
     if bytes is str:
+        # must be able to tell the difference between bytes and a hexstr
         raise NotImplementedError("This method only works in Python 3+.")
 
     if isinstance(val, str):

--- a/web3/utils/validation.py
+++ b/web3/utils/validation.py
@@ -1,3 +1,4 @@
+import itertools
 import sys
 
 from eth_utils import (
@@ -117,3 +118,17 @@ def validate_address_checksum(value):
     if is_checksum_formatted_address(value):
         if not is_checksum_address(value):
             raise ValueError("'{0}' has an invalid EIP55 checksum".format(value))
+
+
+def has_one_val(*args, **kwargs):
+    vals = itertools.chain(args, kwargs.values())
+    not_nones = list(filter(lambda val: val is not None, vals))
+    return len(not_nones) == 1
+
+
+def assert_one_val(*args, **kwargs):
+    if not has_one_val(*args, **kwargs):
+        raise TypeError(
+            "Exactly one of the passed values can be specified. "
+            "Instead, values were: %r, %r" % (args, kwargs)
+        )


### PR DESCRIPTION
### What was wrong?

`toAscii` is not quite semantically right: it outputs bytes that may not be valid ascii.

### Still To-do

- [x] mark `toAscii` deprecated
- [x] use a converter that doesn't `force_text` or `force_bytes`
- [x] move `toBytes` and `toText` to web3.utils.encoding
- [ ] update docs, from to/fromAscii and to/fromUtf8 to `toBytes` or `toText`, as appropriate
- [x] pass all tests
- [ ] py2 deprecation warning (probably a separate PR, though, for discussion)

### How was it fixed?

Added `toBytes` and `toText`, with `toAscii` remaining for backwards compatibility.

Moving away from `fromAscii` concept, specifying the from type in the argument instead. Like `toBytes(hexstr='0x...')`

With bonus import alphabetizing.

#### Cute Animal Picture

![Cute animal picture](https://i.pinimg.com/236x/c8/d2/87/c8d287fa4711c9f100040c792fb7a0f1--baby-koala-koala-bears.jpg)
