### PR TITLE
Removed duplicate bytecode_rumtime definition

### DIFF
--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -77,12 +77,6 @@ Each Contract Factory exposes the following properties.
     provided during factory creation.
 
 
-.. py:attribute:: Contract.bytecode_runtime
-
-    The runtime part of the contract bytecode string.  May be ``None`` if not
-    provided during factory creation.
-
-
 Methods
 -------
 


### PR DESCRIPTION
### What was wrong?



### How was it fixed?



#### Cute Animal Picture

![Cute animal picture]()
