### PR TITLE
Convert readme to rst for pypi description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,12 +32,13 @@ setup(
     name='web3',
     version='3.13.5',
     description="""Web3.py""",
-    long_description=readme,
+    long_description_markdown_filename='README.md',
     author='Piper Merriam',
     author_email='pipermerriam@gmail.com',
     url='https://github.com/pipermerriam/web3.py',
     include_package_data=True,
     install_requires=install_requires,
+    setup_requires=['setuptools-markdown'],
     extras_require={
         'tester': ["eth-testrpc>=1.2.0"],
         'gevent': [


### PR DESCRIPTION
Fixes #38

### What was wrong?

Formatting wonky on pypi site

### How was it fixed?

`setuptools-markdown` converts from markdown to restructured text (if `pandoc` installed)

#### Cute Animal Picture

![Cute animal picture](https://i.pinimg.com/236x/c3/c5/49/c3c5496cbf9b807c2d9b035639f397ea.jpg)
