### PR TITLE
More consistency with JSON-RPC in toHex, and new docs

### DIFF
--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -159,7 +159,7 @@ will return a :py:class::`ShhFilter` object
         >>>def filter_callback(new_message):
         ...     sys.stdout.write("New Shh Message: {0}".format(new_message))
         ...
-        >>>shh_filter = web3.shh.filter({"topics":[web3.fromAscii("topic_to_subscribe")]})
+        >>>shh_filter = web3.shh.filter({"topics":[web3.toHex(text="topic_to_subscribe")]})
         >>>shh_filter.watch(filter_callback)
         #each time client recieves a Shh messages matching the topics subscibed,
         #filter_callback is called

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -42,93 +42,125 @@ operating system.
 Base API
 --------
 
-The ``web3`` object itself exposes the following convenience APIs.
+The ``Web3`` class exposes the following convenience APIs.
 
 
-.. py:method:: Web3.toHex(value)
+.. _overview_type_conversions:
 
-    Takes a string or numeric value and returns it in its hexidecimal representation.
+Type Conversions
+~~~~~~~~~~~~~~~~
 
+.. py:method:: Web3.toHex(primitive=None, hexstr=None, text=None)
+
+    Takes a variety of inputs and returns it in its hexidecimal representation.
+    It follows the rules for converting to hex in the
+    `JSON-RPC spec`_
 
     .. code-block:: python
 
-        >>> web3.toHex(0)
+        >>> Web3.toHex(0)
         '0x0'
-        >>> web3.toHex(1)
+        >>> Web3.toHex(1)
         '0x1'
-        >>> web3.toHex('abcd')
-        '0x61626364'
+        >>> Web3.toHex(0x0)
+        '0x0'
+        >>> Web3.toHex(0x000F)
+        '0xf'
+        >>> Web3.toHex(b'')
+        '0x'
+        >>> Web3.toHex(b'\x00\x0F')
+        '0x000f'
+        >>> Web3.toHex(False)
+        '0x0'
+        >>> Web3.toHex(True)
+        '0x1'
+        >>> Web3.toHex(hexstr='0x000F')
+        '0x000f'
+        >>> Web3.toHex(hexstr='000F')
+        '0x000f'
+        >>> Web3.toHex(text='')
+        '0x'
+        >>> Web3.toHex(text='cowmö')
+        '0x636f776dc3b6'
 
+.. _JSON-RPC spec: https://github.com/ethereum/wiki/wiki/JSON-RPC#hex-value-encoding
 
-.. py:method:: Web3.toAscii(value)
+.. py:method:: Web3.toText(primitive=None, hexstr=None, text=None)
 
-    Takes a hexidecimal encoded string and returns its ascii equivalent.
-
-
-    .. code-block:: python
-
-        >>> web3.toAscii('0x61626364')
-        b'abcd'
-
-
-.. py:method:: Web3.toUtf8(value)
-
-    Takes a hexidecimal encoded string and returns the UTF8 encoded equivalent.
-
-
-    .. code-block:: python
-
-        >>> web3.toUtf8('0x61626364')
-        'abcd'
-
-
-.. py:method:: Web3.fromAscii(value)
-
-    Takes an ascii string and returns it in its hexidecimal representation
-
-
-    .. code-block:: python
-
-        >>> web3.fromAscii(b'abcd')
-        '0x61626364'
-
-
-.. py:method:: Web3.fromUtf8(value)
-
-    Takes a utf8 encoded string and returns it in its hexidecimal representation
+    Takes a variety of inputs and returns its string equivalent.
+    Text gets decoded as UTF-8.
 
 
     .. code-block:: python
 
-        >>> web3.fromUtf8('abcd')
-        '0x61626364'
+        >>> Web3.toText(0x636f776dc3b6)
+        'cowmö'
+        >>> Web3.toText(b'cowm\xc3\xb6')
+        'cowmö'
+        >>> Web3.toText(hexstr='0x636f776dc3b6')
+        'cowmö'
+        >>> Web3.toText(hexstr='636f776dc3b6')
+        'cowmö'
+        >>> Web3.toText(text='cowmö')
+        'cowmö'
 
 
-.. py:method:: Web3.toDecimal(value)
+.. py:method:: Web3.toBytes(primitive=None, hexstr=None, text=None)
 
-    Takes a hexidecimal encoded value and returns its numeric representation.
+    Takes a variety of inputs and returns its bytes equivalent.
+    Text gets encoded as UTF-8.
 
 
     .. code-block:: python
 
-        >>> web3.toDecimal('0x1')
+        >>> Web3.toBytes(0)
+        b'\x00'
+        >>> Web3.toBytes(0x000F)
+        b'\x0f'
+        >>> Web3.toBytes(b'')
+        b''
+        >>> Web3.toBytes(b'\x00\x0F')
+        b'\x00\x0f'
+        >>> Web3.toBytes(False)
+        b'\x00'
+        >>> Web3.toBytes(True)
+        b'\x01'
+        >>> Web3.toBytes(hexstr='0x000F')
+        b'\x00\x0f'
+        >>> Web3.toBytes(hexstr='000F')
+        b'\x00\x0f'
+        >>> Web3.toBytes(text='')
+        b''
+        >>> Web3.toBytes(text='cowmö')
+        b'cowm\xc3\xb6'
+
+
+.. py:method:: Web3.toDecimal(primitive=None, hexstr=None, text=None)
+
+    Takes a variety of inputs and returns its int equivalent.
+
+
+    .. code-block:: python
+
+        >>> Web3.toDecimal(0)
+        0
+        >>> Web3.toDecimal(0x000F)
+        15
+        >>> Web3.toDecimal(b'\x00\x0F')
+        15
+        >>> Web3.toDecimal(False)
+        0
+        >>> Web3.toDecimal(True)
         1
-        >>> web3.toDecimal('0xf')
+        >>> Web3.toDecimal(hexstr='0x000F')
+        15
+        >>> Web3.toDecimal(hexstr='000F')
         15
 
+.. _overview_currency_conversions:
 
-.. py:method:: Web3.fromDecimal(value)
-
-    Takes a numeric value and returns its hexidecimal equivalent.
-
-
-    .. code-block:: python
-
-        >>> web3.fromDecimal(1)
-        '0x1'
-        >>> web3.fromDecimal(15)
-        '0xf'
-
+Currency Conversions
+~~~~~~~~~~~~~~~~
 
 .. py:method:: Web3.toWei(value, currency)
 
@@ -138,25 +170,34 @@ The ``web3`` object itself exposes the following convenience APIs.
 
     .. code-block:: python
 
-        >>> web3.toWei(1, 'ether')
+        >>> Web3.toWei(1, 'ether')
         1000000000000000000
 
 
 .. py:method:: Web3.fromWei(value, currency)
 
-    Returns the value in wei converted to the given currency.
+    Returns the value in wei converted to the given currency. The value is returned
+    as a ``Decimal`` to ensure precision down to the wei.
 
 
     .. code-block:: python
 
         >>> web3.fromWei(1000000000000000000, 'ether')
-        1
+        Decimal('1')
 
+
+.. _overview_addresses:
+
+Addresses
+~~~~~~~~~~~~~~~~
 
 .. py:method:: Web3.isAddress(value)
 
     Returns ``True`` if the value is one of the recognized address formats.
 
+    * Allows for both ``0x`` prefixed and non-prefixed values.
+    * If the address contains mixed upper and lower cased characters this function also
+      checks if the the address checksum is valid according to `EIP55`_
 
     .. code-block:: python
 
@@ -166,7 +207,7 @@ The ``web3`` object itself exposes the following convenience APIs.
 
 .. py:method:: Web3.isChecksumAddress(value)
 
-    Returns ``True`` if the value is a valid ERC55 checksummed address
+    Returns ``True`` if the value is a valid `EIP55`_ checksummed address
 
 
     .. code-block:: python
@@ -179,14 +220,21 @@ The ``web3`` object itself exposes the following convenience APIs.
 
 .. py:method:: Web3.toChecksumAddress(value)
 
-    Returns the given address with an ERC55 checksum.
+    Returns the given address with an `EIP55`_ checksum.
 
 
     .. code-block:: python
 
-        >>> web3.toChecksumAddress('0xd3cda913deb6f67967b99d67acdfa1712c293601')
+        >>> Web3.toChecksumAddress('0xd3cda913deb6f67967b99d67acdfa1712c293601')
         '0xd3CDA913deB6f67967B99D67aCDFa1712C293601'
 
+.. _EIP55: https://github.com/ethereum/EIPs/issues/55
+
+
+.. _overview_hashing:
+
+Cryptographic Hashing
+~~~~~~~~~~~~~~~~
 
 .. py:method:: Web3.sha3(primitive=None, hexstr=None, text=None)
 

--- a/docs/web3.main.rst
+++ b/docs/web3.main.rst
@@ -38,79 +38,19 @@ Providers
 Encoding and Decoding Helpers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. py:staticmethod:: Web3.toHex(value)
-
-    Returns the unpadded hexidecimal representation for the given
-    ``value``.  This function supports the following types.
-
-    * Booleans: Returns ``0x0`` or ``0x1``
-    * Strings: Returns the string bytes in their hexidecimal representation.
-    * Integers: Returns the integer value in it's hexidecimal representation.
-    * Dictionaries: Returns the hexidecimal representation of the
-      dictionary converted to a JSON string.
-
-.. py:staticmethod:: Web3.toAscii(hex_value)
-
-    Takes a hexidecimal value and returns it in its bytes representation.
-    
-.. py:staticmethod:: Web3.toUtf8(value)
-
-    Takes a hexidecimal value and returns it in its text representation.
-
-.. py:staticmethod:: Web3.fromAscii(value)
-
-    Takes a byte string and returns its hexidecimal representation.
-
-.. py:staticmethod:: Web3.fromUtf8(value)
-
-    Takes a text string and returns its hexidecimal representation.
-
-.. py:staticmethod:: Web3.toDecimal(value)
-
-    Takes a hexidecimal value and returns it as its integer representation.
-
-.. py:staticmethod:: Web3.fromDecimal(value)
-
-    Takes an integer value and returns its hexidecimal representation.
+See :ref:`overview_type_conversions`
 
 
-Currency Converstions
+Currency Conversions
 ~~~~~~~~~~~~~~~~~~~~~
 
-.. py:staticmethod:: Web3.toWei(value, unit)
-
-    Takes a value in the given ``unit`` and returns it converted to Wei.
-
-.. py:staticmethod:: Web3.fromWei(value, unit)
-
-    Takes a value in Wei and converts it to the given unit.
-
-    .. note::
-    
-        The return type of this function is a very high precision
-        ``decimal.Decimal`` value to ensure there are no rounding errors.
+See :ref:`overview_currency_conversions`
 
 
 Addresses
 ~~~~~~~~~
 
-.. py:staticmethod:: Web3.isAddress(value)
-
-    Return boolean indicating whether the value passed in is a valid
-    hexidecimal encoded Ethereum address.
-
-    * Allows for both ``0x`` prefixed and non-prefixed values.
-    * If the address contains mixed upper and lower cased characters this function also checks if the the address checksum is valid according to `EIP55`_
-
-    
-.. py:staticmethod:: Web3.isChecksumAddress(address)
-
-    Returns boolean as to whether the given address is checksummed according to
-    `EIP55`_
-
-.. py:staticmethod:: Web3.toChecksumAddress(address)
-
-    Returns the given address checksummed according to `EIP55`_
+See :ref:`overview_addresses`
 
 
 RPC APIS
@@ -149,4 +89,3 @@ Each ``web3`` instance also exposes these namespaced APIs.
     See :doc:`./web3.admin`
 
 
-.. _EIP55: https://github.com/ethereum/EIPs/issues/55

--- a/docs/web3.shh.rst
+++ b/docs/web3.shh.rst
@@ -37,7 +37,7 @@ The following methods are available on the ``web3.shh`` namespace.
 
     .. code-block:: python
     
-        >>>web3.shh.post({"topics":[web3.fromAscii("test_topic")],"payload":web3.fromAscii("test_payload")})
+        >>>web3.shh.post({"topics":[web3.toHex(text="test_topic")],"payload":web3.toHex(text="test_payload")})
         True
 
 .. py:method:: Shh.newIdentity(self)
@@ -88,7 +88,7 @@ The following methods are available on the ``web3.shh`` namespace.
 
     .. code-block:: python
 
-        >>>shh_filter = shh.filter({"topics":[web.fromAscii("topic_to_subscribe")]})
+        >>>shh_filter = shh.filter({"topics":[web.toHex(text="topic_to_subscribe")]})
         >>>shh_filter.filter_id
         u'0x0'
 

--- a/tests/core/web3-module/test_conversions.py
+++ b/tests/core/web3-module/test_conversions.py
@@ -14,7 +14,8 @@ from web3 import Web3
         (b'\x01', b'\x01'),
         (b'\xff', b'\xff'),
         (b'\x00', b'\x00'),
-        (0x01, b'\x01'),
+        (0x1, b'\x01'),
+        (0x0001, b'\x01'),
         (0xFF, b'\xff'),
         (0, b'\x00'),
         (256, b'\x01\x00'),
@@ -37,6 +38,7 @@ def test_to_bytes_primitive(val, expected):
         ('0xFF', b'\xff'),
         ('0x100', b'\x01\x00'),
         ('0x0000', b'\x00\x00'),
+        ('0000', b'\x00\x00'),
     )
 )
 def test_to_bytes_hexstr(val, expected):
@@ -87,6 +89,7 @@ def test_to_text(val, expected):
         ('0x', ''),
         ('0xa', '\n'),
         ('0x636f776dc3b6', 'cowmö'),
+        ('636f776dc3b6', 'cowmö'),
     )
 )
 def test_to_text_hexstr(val, expected):
@@ -155,15 +158,18 @@ def test_to_decimal_hexstr(val, expected):
 @pytest.mark.parametrize(
     'val, expected',
     (
-        (b'\x00', '0x0'),
-        (b'\x01', '0x1'),
+        (b'\x00', '0x00'),
+        (b'\x01', '0x01'),
         (b'\x10', '0x10'),
-        (b'\x01\x00', '0x100'),
+        (b'\x01\x00', '0x0100'),
+        (b'\x00\x0F', '0x000f'),
         (b'', '0x'),
         (0, '0x0'),
         (1, '0x1'),
         (16, '0x10'),
         (256, '0x100'),
+        (0x0, '0x0'),
+        (0x0F, '0xf'),
         (False, '0x0'),
         (True, '0x1'),
     )
@@ -188,8 +194,10 @@ def test_to_hex_text(val, expected):
     (
         ('0x0', '0x0'),
         ('0x1', '0x1'),
-        ('0x01', '0x1'),
+        ('0x0001', '0x0001'),
         ('0x10', '0x10'),
+        ('0xF', '0xf'),
+        ('F', '0xf'),
     )
 )
 def test_to_hex_cleanup_only(val, expected):

--- a/web3/utils/decorators.py
+++ b/web3/utils/decorators.py
@@ -37,7 +37,8 @@ def reject_recursive_repeats(to_wrap):
 def deprecated_for(replace_message):
     '''
     Decorate a deprecated function, with info about what to use instead, like:
-    @deprecated("toBytes()")
+
+    @deprecated_for("toBytes()")
     def toAscii(arg):
         ...
     '''

--- a/web3/utils/encoding.py
+++ b/web3/utils/encoding.py
@@ -128,7 +128,7 @@ def to_hex(value=None, hexstr=None, text=None):
     assert_one_val(value, hexstr=hexstr, text=text)
 
     if hexstr is not None:
-        return trim_hex(hexstr)
+        return add_0x_prefix(hexstr.lower())
 
     if text is not None:
         return encode_hex(text.encode('utf-8'))
@@ -140,8 +140,7 @@ def to_hex(value=None, hexstr=None, text=None):
         return encode_hex(json.dumps(value, sort_keys=True))
 
     if isinstance(value, bytes):
-        padded = encode_hex(value)
-        return trim_hex(padded)
+        return encode_hex(value)
     elif is_string(value):
         return to_hex(text=value)
 


### PR DESCRIPTION
### What was wrong?

No docs for the new type conversions
`toHex` was stripping leading 0's when it shouldn't, according to JSON-RPC docs

### How was it fixed?

Added/updated tests, and pass them.

Lots of new docs.

#### Cute Animal Picture

![Cute animal picture](http://www.wallpapersin4k.org/wp-content/uploads/2017/04/Cute-Chicken-Wallpaper-6.jpg)
