### PR TITLE
'function' type is encodable in new abi utils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ readme = open(os.path.join(DIR, 'README.md')).read()
 
 install_requires = [
     "cytoolz>=0.8.2",
-    "ethereum-abi-utils>=0.4.0",
+    "ethereum-abi-utils>=0.4.1",
     "ethereum-utils>=0.4.0",
     "pylru>=1.0.9",
     "pysha3>=0.3",

--- a/tests/core/utilities/test_abi_is_encodable.py
+++ b/tests/core/utilities/test_abi_is_encodable.py
@@ -30,6 +30,12 @@ from web3.utils.abi import (
         (2**256, 'uint256', False),
         ('abc', 'uint256', False),
         (True, 'uint256', False),
+        # function
+        (0, 'function', False),
+        (b'\0' * 24, 'function', True),
+        (b'\0' * 25, 'function', False),
+        (True, 'function', False),
+        (False, 'function', False),
     ),
 )
 def test_is_encodable(value, _type, expected):


### PR DESCRIPTION
### What was wrong?

The ABI type 'function' was raising an exception as unsupported.

### How was it fixed?

Import the new `ethereum-abi-utils` library. Add tests to confirm that function is supported.

#### Cute Animal Picture

![Cute animal picture](https://i.pinimg.com/originals/90/a8/e6/90a8e6a171cd11132081fa9cc1fb2b04.jpg)
