### PR TITLE
use collapse_type() from eth_abi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ readme = open(os.path.join(DIR, 'README.md')).read()
 
 install_requires = [
     "cytoolz>=0.8.2",
-    "ethereum-abi-utils>=0.4.2",
+    "ethereum-abi-utils>=0.4.3",
     "ethereum-utils>=0.4.0",
     "pylru>=1.0.9",
     "pysha3>=0.3",

--- a/tests/core/utilities/test_abi.py
+++ b/tests/core/utilities/test_abi.py
@@ -1,33 +1,11 @@
 
 import pytest
 
-from eth_abi.abi import (
-    process_type,
-)
-
 from web3.utils.abi import (
     BASE_RETURN_NORMALIZERS,
     abi_data_tree,
-    collapse_type,
     map_abi_data,
 )
-
-
-@pytest.mark.parametrize(
-    'original, expected',
-    [
-        ('address', 'address'),
-        ('uint[2][]', 'uint256[2][]'),
-        ('uint256[2][]', 'uint256[2][]'),
-        ('function', 'bytes24'),
-        ('bool', 'bool'),
-        ('bytes32', 'bytes32'),
-        ('bytes', 'bytes'),
-        ('string', 'string'),
-    ],
-)
-def test_collapse_type(original, expected):
-    assert collapse_type(*process_type(original)) == expected
 
 
 @pytest.mark.parametrize(

--- a/web3/utils/abi.py
+++ b/web3/utils/abi.py
@@ -23,6 +23,7 @@ from eth_utils import (
 )
 
 from eth_abi.abi import (
+    collapse_type,
     process_type,
 )
 
@@ -509,11 +510,6 @@ def abi_sub_tree(data_type, data_value):
         ])
     else:
         return ABITypedData([collapsed, data_value])
-
-
-# This will be implemented in eth_abi soon
-def collapse_type(base, sub, arrlist):
-    return str(base + sub + ''.join(map(repr, arrlist)))
 
 
 def strip_abi_type(elements):


### PR DESCRIPTION
### What was wrong?

`collapse_type` was defined in web3 instead of eth_abi.

### How was it fixed?

bumped eth_abi and removed collapse_type

#### Cute Animal Picture

![Cute animal picture](https://i.pinimg.com/originals/70/fc/77/70fc77bc8d5c0f6d8e1f864e01d5d690.jpg)
