### PR TITLE
Add module with 1 line & add submodule to a module

### DIFF
--- a/web3/main.py
+++ b/web3/main.py
@@ -111,12 +111,7 @@ class Web3(object):
             modules = get_default_modules()
 
         for module_name, module_class in modules.items():
-            if hasattr(self, module_name):
-                raise AttributeError(
-                    "Cannot set web3 module named '{0}'.  The web3 object "
-                    "already has an attribute with that name".format(module_name)
-                )
-            setattr(self, module_name, module_class(self))
+            module_class.attach(self, module_name)
 
     def add_middleware(self, middleware):
         """

--- a/web3/module.py
+++ b/web3/module.py
@@ -3,3 +3,24 @@ class Module(object):
 
     def __init__(self, web3):
         self.web3 = web3
+
+    @classmethod
+    def attach(cls, target, module_name=None):
+        if not module_name:
+            module_name = cls.__name__.lower()
+
+        if hasattr(target, module_name):
+            raise AttributeError(
+                "Cannot set {0} module named '{1}'.  The web3 object "
+                "already has an attribute with that name".format(
+                    target,
+                    module_name,
+                )
+            )
+
+        if isinstance(target, Module):
+            web3 = target.web3
+        else:
+            web3 = target
+
+        setattr(target, module_name, cls(web3))


### PR DESCRIPTION
### What was wrong?

Adding a module took a bit of boilerplate, which was fine because it only happened once in web3. Soon we will have modules inside modules.

### How was it fixed?

Extract code for attaching a module to Web3 to a class method in Module. Detect if the attaching target is itself a Module, and if so, reuse that target's web3 instance.

#### Cute Animal Picture

![Cute animal picture](https://photorator.com/photos/images/silkie-chickens--30013.jpg)
