### PR TITLE
curry conditional type converters

### DIFF
--- a/tests/core/utilities/test_encoding.py
+++ b/tests/core/utilities/test_encoding.py
@@ -155,6 +155,11 @@ def test_hexstr_if_str_passthrough(val):
     assert to_type.call_args == ((val, ), {'hexstr': None})
 
 
+def test_hexstr_if_str_curried():
+    converter = hexstr_if_str(to_hex)
+    assert converter(255) == '0xff'
+
+
 @only_python3
 @given(st.from_regex(HEX_REGEX))
 @example('0x')

--- a/web3/utils/encoding.py
+++ b/web3/utils/encoding.py
@@ -6,6 +6,10 @@ import warnings
 
 from rlp.sedes import big_endian_int
 
+from cytoolz import (
+    curry,
+)
+
 from eth_utils import (
     add_0x_prefix,
     coerce_args_to_bytes,
@@ -235,6 +239,7 @@ def to_text(primitive=None, hexstr=None, text=None):
     raise TypeError("Expected an int, bytes or hexstr.")
 
 
+@curry
 def text_if_str(to_type, text_or_primitive):
     '''
     Convert to a type, assuming that strings can be only unicode text (not a hexstr)
@@ -257,6 +262,7 @@ def text_if_str(to_type, text_or_primitive):
     return to_type(primitive, text=text)
 
 
+@curry
 def hexstr_if_str(to_type, hexstr_or_primitive):
     '''
     Convert to a type, assuming that strings can be only hexstr (not unicode text)


### PR DESCRIPTION
### What was wrong?

Functional composition with `hexstr_if_str` and `text_if_str` is inconvenient.

### How was it fixed?

Curry them

#### Cute Animal Picture

![Cute animal picture](https://i.pinimg.com/originals/fe/f3/72/fef37274b6b285babe8f2aa8738fb008.jpg)
