### PR TITLE
Warn that py2 is deprecated, plus guidance in docs

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -4,6 +4,22 @@ Quickstart
 .. contents:: :local:
 
 
+Environment
+------------
+
+Web3.py prefers Python 3, and will soon require it. Often, the
+best way to guarantee a clean Python 3 environment is with ``virtualenv``, like:
+
+.. code-block:: shell
+
+    # once:
+    $ virtualenv -p python3 ~/.venv-py3
+
+    # each session:
+    $ source ~/.venv-py3/bin/activate
+
+    # with virtualenv active, install...
+
 Installation
 ------------
 

--- a/web3/main.py
+++ b/web3/main.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import sys
 import warnings
 
 from eth_utils import (
@@ -105,6 +106,8 @@ class Web3(object):
     toChecksumAddress = staticmethod(to_checksum_address)
 
     def __init__(self, providers, middlewares=None, modules=None):
+        self._deprecation_warn()
+
         self.manager = RequestManager(self, providers, middlewares)
 
         if modules is None:
@@ -112,6 +115,16 @@ class Web3(object):
 
         for module_name, module_class in modules.items():
             module_class.attach(self, module_name)
+
+    def _deprecation_warn(self):
+        if sys.version_info.major < 3:
+            warnings.simplefilter('always', DeprecationWarning)
+            warnings.warn(
+                "Python 2 support is ending! Please upgrade to Python 3 promptly."
+                " Support will end at the beginning of 2018.",
+                category=DeprecationWarning,
+            )
+            warnings.simplefilter('default', DeprecationWarning)
 
     @property
     def middleware_stack(self):


### PR DESCRIPTION
### What was wrong?

#300 Needed to warn about py2 deprecation.

### How was it fixed?

Added deprecation warning, plus an environment note in the docs

Also, trying out merging to the v3 branch, a la #336 

For backported items that belong in both versions, we can manually merge to master after doing a PR to v3. Any better idea?

#### Cute Animal Picture

![Cute animal picture](https://media.mnn.com/assets/images/2014/01/Blue-blanket-JF_0.jpg.838x0_q80.jpg)
