### PR TITLE
remove python tests for py2 and py3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,49 +10,33 @@ matrix:
   include:
     # go-ethereum
     - python: "3.5"
-      env: TOX_POSARGS="-e py27-integration-goethereum -e py34-integration-goethereum -e py35-integration-goethereum" GETH_VERSION=v1.6.0
+      env: TOX_POSARGS="-e py35-integration-goethereum" GETH_VERSION=v1.6.0
     - python: "3.5"
-      env: TOX_POSARGS="-e py27-integration-goethereum -e py34-integration-goethereum -e py35-integration-goethereum" GETH_VERSION=v1.6.1
+      env: TOX_POSARGS="-e py35-integration-goethereum" GETH_VERSION=v1.6.1
     # 1.6.2 and 1.6.3 are failing due to go-ethereum internal errors.
     - python: "3.5"
-      env: TOX_POSARGS="-e py27-integration-goethereum -e py34-integration-goethereum -e py35-integration-goethereum" GETH_VERSION=v1.6.4
+      env: TOX_POSARGS="-e py35-integration-goethereum" GETH_VERSION=v1.6.4
     - python: "3.5"
-      env: TOX_POSARGS="-e py27-integration-goethereum -e py34-integration-goethereum -e py35-integration-goethereum" GETH_VERSION=v1.6.5
+      env: TOX_POSARGS="-e py35-integration-goethereum" GETH_VERSION=v1.6.5
     - python: "3.5"
-      env: TOX_POSARGS="-e py27-integration-goethereum -e py34-integration-goethereum -e py35-integration-goethereum" GETH_VERSION=v1.6.6
+      env: TOX_POSARGS="-e py35-integration-goethereum" GETH_VERSION=v1.6.6
     - python: "3.5"
-      env: TOX_POSARGS="-e py27-integration-goethereum -e py34-integration-goethereum -e py35-integration-goethereum" GETH_VERSION=v1.6.7
+      env: TOX_POSARGS="-e py35-integration-goethereum" GETH_VERSION=v1.6.7
     - python: "3.5"
-      env: TOX_POSARGS="-e py27-integration-goethereum -e py34-integration-goethereum -e py35-integration-goethereum" GETH_VERSION=v1.7.0
+      env: TOX_POSARGS="-e py35-integration-goethereum" GETH_VERSION=v1.7.0
     # lint
     - python: "3.5"
       env: TOX_POSARGS="-e flake8"
     # core-stdlib
-    - python: "2.7"
-      env: TOX_POSARGS="-e py27-core-stdlib"
-    - python: "3.4"
-      env: TOX_POSARGS="-e py34-core-stdlib"
     - python: "3.5"
       env: TOX_POSARGS="-e py35-core-stdlib"
     # core-gevent
-    - python: "2.7"
-      env: TOX_POSARGS="-e py27-core-gevent"
-    - python: "3.4"
-      env: TOX_POSARGS="-e py34-core-gevent"
     - python: "3.5"
       env: TOX_POSARGS="-e py35-core-gevent"
     # eth-testrpc
-    - python: "2.7"
-      env: TOX_POSARGS="-e py27-integration-ethtestrpc"
-    - python: "3.4"
-      env: TOX_POSARGS="-e py34-integration-ethtestrpc"
     - python: "3.5"
       env: TOX_POSARGS="-e py35-integration-ethtestrpc"
     # eth-tester-pyethereum16
-    - python: "2.7"
-      env: TOX_POSARGS="-e py27-integration-ethtester" ETHEREUM_TESTER_CHAIN_BACKEND=eth_tester.backends.PyEthereum16Backend
-    - python: "3.4"
-      env: TOX_POSARGS="-e py34-integration-ethtester" ETHEREUM_TESTER_CHAIN_BACKEND=eth_tester.backends.PyEthereum16Backend
     - python: "3.5"
       env: TOX_POSARGS="-e py35-integration-ethtester" ETHEREUM_TESTER_CHAIN_BACKEND=eth_tester.backends.PyEthereum16Backend
     # eth-tester-pyevm

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=
-    py{27,34,35}-core-{gevent,stdlib}
-    py{27,34,35}-integration-{ethtestrpc,goethereum,ethtester}
+    py35-core-{gevent,stdlib}
+    py35-integration-{ethtestrpc,goethereum,ethtester}
     flake8
 
 [flake8]
@@ -29,8 +29,6 @@ passenv =
     GOROOT
     GOPATH
 basepython =
-    py27: python2.7
-    py34: python3.4
     py35: python3.5
 
 [testenv:flake8]


### PR DESCRIPTION
### What was wrong?

We are unnecessarily testing against old Python versions on v4 (`master` branch), slowing the test process.

### How was it fixed?

Removed the tox environments and travis runs

#### Cute Animal Picture

![Cute animal picture](https://i.ytimg.com/vi/RoH1Km7VFyc/hqdefault.jpg)
