### PR TITLE
Reuse IPC Socket

### DIFF
--- a/web3/providers/ipc.py
+++ b/web3/providers/ipc.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 import sys
 import os
-import contextlib
 
 try:
     from json import JSONDecodeError
@@ -18,21 +17,38 @@ from web3.utils.compat import (
 from .base import JSONBaseProvider
 
 
-@contextlib.contextmanager
 def get_ipc_socket(ipc_path, timeout=0.1):
     if sys.platform == 'win32':
         # On Windows named pipe is used. Simulate socket with it.
         from web3.utils.windows import NamedPipe
 
-        pipe = NamedPipe(ipc_path)
-        with contextlib.closing(pipe):
-            yield pipe
+        return NamedPipe(ipc_path)
     else:
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         sock.connect(ipc_path)
         sock.settimeout(timeout)
-        with contextlib.closing(sock):
-            yield sock
+        return sock
+
+
+class PersistantSocket(object):
+    sock = None
+
+    def __init__(self, ipc_path):
+        self.ipc_path = ipc_path
+
+    def __enter__(self):
+        if not self.sock:
+            self.sock = get_ipc_socket(self.ipc_path)
+        return self.sock
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        # only close the socket if there was an error
+        if exc_value is not None:
+            try:
+                self.sock.close()
+            except:
+                pass
+            self.sock = None
 
 
 def get_default_ipc_path(testnet=False):
@@ -66,6 +82,8 @@ def get_default_ipc_path(testnet=False):
 
 
 class IPCProvider(JSONBaseProvider):
+    _socket = None
+
     def __init__(self, ipc_path=None, testnet=False, *args, **kwargs):
         if ipc_path is None:
             self.ipc_path = get_default_ipc_path(testnet)
@@ -73,36 +91,29 @@ class IPCProvider(JSONBaseProvider):
             self.ipc_path = ipc_path
 
         self._lock = threading.Lock()
+        self._socket = PersistantSocket(self.ipc_path)
         super(IPCProvider, self).__init__(*args, **kwargs)
 
     def make_request(self, method, params):
         request = self.encode_rpc_request(method, params)
 
-        self._lock.acquire()
-
-        try:
-            with get_ipc_socket(self.ipc_path) as sock:
-                sock.sendall(request)
-                # TODO: use a BytesIO object here
-                raw_response = b""
-
-                with Timeout(10) as timeout:
-                    while True:
+        with self._lock, self._socket as sock:
+            sock.sendall(request)
+            raw_response = b""
+            with Timeout(10) as timeout:
+                while True:
+                    try:
+                        raw_response += sock.recv(4096)
+                    except socket.timeout:
+                        timeout.sleep(0)
+                        continue
+                    if raw_response == b"":
+                        timeout.sleep(0)
+                    else:
                         try:
-                            raw_response += sock.recv(4096)
-                        except socket.timeout:
+                            response = self.decode_rpc_response(raw_response)
+                        except JSONDecodeError:
                             timeout.sleep(0)
                             continue
-
-                        if raw_response == b"":
-                            timeout.sleep(0)
                         else:
-                            try:
-                                response = self.decode_rpc_response(raw_response)
-                            except JSONDecodeError:
-                                timeout.sleep(0)
-                                continue
-                            else:
-                                return response
-        finally:
-            self._lock.release()
+                            return response


### PR DESCRIPTION
### What was wrong?

When making many consecutive requests over IPC, they were slow, used a lot of RAM, and eventually crashed Parity. See https://github.com/paritytech/parity/issues/6516

### How was it fixed?

Reuse IPC connection across requests.

Thanks @ifA88 for testing out that the approach has a significant performance boost.

#### Cute Animal Picture

![Cute animal picture](http://2.bp.blogspot.com/-8nNiebzBrqY/VV9_wwKpPDI/AAAAAAAAAJI/_mC_TQdlMCo/s1600/bottlenose-dolphins.jpg)
