### PR TITLE
[v3] return checksum addresses from json-rpc calls

### DIFF
--- a/tests/core/contracts/test_extracting_event_data.py
+++ b/tests/core/contracts/test_extracting_event_data.py
@@ -1,8 +1,9 @@
 import pytest
 
 from eth_utils import (
-    force_text,
     decode_hex,
+    force_text,
+    is_same_address,
 )
 
 from web3.utils.events import (
@@ -100,7 +101,7 @@ def test_event_data_extraction(web3,
     assert event_data['blockHash'] == txn_receipt['blockHash']
     assert event_data['blockNumber'] == txn_receipt['blockNumber']
     assert event_data['transactionIndex'] == txn_receipt['transactionIndex']
-    assert event_data['address'] == emitter.address
+    assert is_same_address(event_data['address'], emitter.address)
     assert event_data['event'] == event_name
 
 
@@ -136,5 +137,5 @@ def test_dynamic_length_argument_extraction(web3,
     assert event_data['blockHash'] == txn_receipt['blockHash']
     assert event_data['blockNumber'] == txn_receipt['blockNumber']
     assert event_data['transactionIndex'] == txn_receipt['transactionIndex']
-    assert event_data['address'] == emitter.address
+    assert is_same_address(event_data['address'], emitter.address)
     assert event_data['event'] == 'LogDynamicArgs'

--- a/tests/core/filtering/test_contract_past_event_filtering.py
+++ b/tests/core/filtering/test_contract_past_event_filtering.py
@@ -1,6 +1,10 @@
 import pytest
 from flaky import flaky
 
+from eth_utils import (
+    is_same_address,
+)
+
 from web3.utils.compat import (
     Timeout,
 )
@@ -41,7 +45,7 @@ def test_past_events_filter_with_callback(web3,
     assert event_data['blockHash'] == txn_receipt['blockHash']
     assert event_data['blockNumber'] == txn_receipt['blockNumber']
     assert event_data['transactionIndex'] == txn_receipt['transactionIndex']
-    assert event_data['address'] == emitter.address
+    assert is_same_address(event_data['address'], emitter.address)
     assert event_data['event'] == 'LogNoArguments'
 
 
@@ -75,5 +79,5 @@ def test_past_events_filter_using_get_api(web3,
     assert event_data['blockHash'] == txn_receipt['blockHash']
     assert event_data['blockNumber'] == txn_receipt['blockNumber']
     assert event_data['transactionIndex'] == txn_receipt['transactionIndex']
-    assert event_data['address'] == emitter.address
+    assert is_same_address(event_data['address'], emitter.address)
     assert event_data['event'] == 'LogNoArguments'

--- a/web3/middleware/pythonic.py
+++ b/web3/middleware/pythonic.py
@@ -15,7 +15,7 @@ from cytoolz.functoolz import (
 
 from eth_utils import (
     is_address,
-    to_normalized_address,
+    to_checksum_address,
     is_integer,
     is_null,
     is_dict,
@@ -86,8 +86,8 @@ TRANSACTION_FORMATTERS = {
     'gas': to_integer_if_hex,
     'gasPrice': to_integer_if_hex,
     'value': to_integer_if_hex,
-    'from': to_normalized_address,
-    'to': apply_formatter_if(to_normalized_address, is_address),
+    'from': to_checksum_address,
+    'to': apply_formatter_if(to_checksum_address, is_address),
     'hash': to_ascii_if_bytes,
 }
 
@@ -100,7 +100,7 @@ LOG_ENTRY_FORMATTERS = {
     'blockNumber': apply_formatter_if(to_integer_if_hex, is_not_null),
     'transactionIndex': apply_formatter_if(to_integer_if_hex, is_not_null),
     'logIndex': to_integer_if_hex,
-    'address': to_normalized_address,
+    'address': to_checksum_address,
     'topics': apply_formatter_to_array(to_ascii_if_bytes),
     'data': to_ascii_if_bytes,
 }
@@ -116,7 +116,7 @@ RECEIPT_FORMATTERS = {
     'transactionHash': to_ascii_if_bytes,
     'cumulativeGasUsed': to_integer_if_hex,
     'gasUsed': to_integer_if_hex,
-    'contractAddress': apply_formatter_if(to_normalized_address, is_not_null),
+    'contractAddress': apply_formatter_if(to_checksum_address, is_not_null),
     'logs': apply_formatter_to_array(log_entry_formatter),
 }
 
@@ -250,9 +250,9 @@ pythonic_middleware = construct_formatting_middleware(
     },
     result_formatters={
         # Eth
-        'eth_accounts': apply_formatter_to_array(to_normalized_address),
+        'eth_accounts': apply_formatter_to_array(to_checksum_address),
         'eth_blockNumber': to_integer_if_hex,
-        'eth_coinbase': to_normalized_address,
+        'eth_coinbase': to_checksum_address,
         'eth_estimateGas': to_integer_if_hex,
         'eth_gasPrice': to_integer_if_hex,
         'eth_getBalance': to_integer_if_hex,

--- a/web3/utils/module_testing/eth_module.py
+++ b/web3/utils/module_testing/eth_module.py
@@ -314,7 +314,7 @@ class EthModuleTest(object):
         assert log_entry['blockNumber'] == block_with_txn_with_log['number']
         assert log_entry['blockHash'] == block_with_txn_with_log['hash']
         assert log_entry['logIndex'] == 0
-        assert log_entry['address'] == emitter_contract.address
+        assert is_same_address(log_entry['address'], emitter_contract.address)
         assert log_entry['transactionIndex'] == 0
         assert log_entry['transactionHash'] == txn_hash_with_log
 


### PR DESCRIPTION
### What was wrong?

Many RPC calls were still returning lowercase hex addresses

### How was it fixed?

Switched all `to_normalized_address` calls to `to_checksum_address`

#### Cute Animal Picture

![Cute animal picture](http://mainenewsonline.com/sites/default/files/styles/large/public/World-Tiniest-Porpoise.jpg)
