### PR TITLE
Return bytes in web3.eth.account

### DIFF
--- a/docs/web3.eth.account.rst
+++ b/docs/web3.eth.account.rst
@@ -159,10 +159,10 @@ The following methods are available on the ``Web3.eth.account`` namespace.
         >>> key = "\xb2\\}\xb3\x1f\xee\xd9\x12''\xbf\t9\xdcv\x9a\x96VK-\xe4\xc4rm\x03[6\xec\xf1\xe5\xb3d"
         >>> w3.eth.account.sign(message_text=msg, private_key=key)
         {'message': b'I\xe2\x99\xa5SF',
-         'messageHash': '0x1476abb745d423bf09273f1afd887d951181d25adc66c4834a70491911b7f750',
-         'r': '0xe6ca9bba58c88611fad66a6ce8f996908195593807c4b38bd528d2cff09d4eb3',
-         's': '0x3e5bfbbf4d3e39b1a2fd816a7680c19ebebaf3a141b239934ad43cb33fcec8ce',
-         'signature': '0xe6ca9bba58c88611fad66a6ce8f996908195593807c4b38bd528d2cff09d4eb33e5bfbbf4d3e39b1a2fd816a7680c19ebebaf3a141b239934ad43cb33fcec8ce1c',
+         'messageHash': HexBytes('0x1476abb745d423bf09273f1afd887d951181d25adc66c4834a70491911b7f750'),
+         'r': HexBytes('0xe6ca9bba58c88611fad66a6ce8f996908195593807c4b38bd528d2cff09d4eb3'),
+         's': HexBytes('0x3e5bfbbf4d3e39b1a2fd816a7680c19ebebaf3a141b239934ad43cb33fcec8ce'),
+         'signature': HexBytes('0xe6ca9bba58c88611fad66a6ce8f996908195593807c4b38bd528d2cff09d4eb33e5bfbbf4d3e39b1a2fd816a7680c19ebebaf3a141b239934ad43cb33fcec8ce1c'),
          'v': 28}
 
         # these are all equivalent:
@@ -290,7 +290,7 @@ The following methods are available on the ``Web3.eth.account`` namespace.
 
         >>> msg = "I♥SF"
         >>> w3.eth.account.hashMessage(text=msg)
-        '0x1476abb745d423bf09273f1afd887d951181d25adc66c4834a70491911b7f750'
+        HexBytes('0x1476abb745d423bf09273f1afd887d951181d25adc66c4834a70491911b7f750')
 
 
 .. py:method:: Account.signTransaction(transaction_dict, private_key)
@@ -318,10 +318,10 @@ The following methods are available on the ``Web3.eth.account`` namespace.
             }
         >>> key = '0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318'
         >>> signed = w3.eth.account.signTransaction(transaction, key)
-        {'hash': '0x6893a6ee8df79b0f5d64a180cd1ef35d030f3e296a5361cf04d02ce720d32ec5',
-         'r': '0x09ebb6ca057a0535d6186462bc0b465b561c94a295bdb0621fc19208ab149a9c',
-         'rawTransaction': '0xf86a8086d55698372431831e848094f0109fc8df283027b6285cc889f5aa624eac1f55843b9aca008025a009ebb6ca057a0535d6186462bc0b465b561c94a295bdb0621fc19208ab149a9ca0440ffd775ce91a833ab410777204d5341a6f9fa91216a6f3ee2c051fea6a0428',
-         's': '0x440ffd775ce91a833ab410777204d5341a6f9fa91216a6f3ee2c051fea6a0428',
+        {'hash': HexBytes('0x6893a6ee8df79b0f5d64a180cd1ef35d030f3e296a5361cf04d02ce720d32ec5'),
+         'r': HexBytes('0x09ebb6ca057a0535d6186462bc0b465b561c94a295bdb0621fc19208ab149a9c'),
+         'rawTransaction': HexBytes('0xf86a8086d55698372431831e848094f0109fc8df283027b6285cc889f5aa624eac1f55843b9aca008025a009ebb6ca057a0535d6186462bc0b465b561c94a295bdb0621fc19208ab149a9ca0440ffd775ce91a833ab410777204d5341a6f9fa91216a6f3ee2c051fea6a0428'),
+         's': HexBytes('0x440ffd775ce91a833ab410777204d5341a6f9fa91216a6f3ee2c051fea6a0428'),
          'v': 37}
         >>> w3.eth.sendRawTransaction(signed.rawTransaction)
 

--- a/tests/core/eth-module/test_accounts.py
+++ b/tests/core/eth-module/test_accounts.py
@@ -10,6 +10,7 @@ from eth_utils import (
     is_hex,
 )
 
+from web3.utils.datastructures import HexBytes
 from web3.utils.encoding import (
     to_bytes,
     to_hex,
@@ -196,16 +197,16 @@ def test_eth_account_recover_vrs_standard_v(web3):
     [
         (
             'Message tö sign. Longer than hash!',
-            '0x10c7cb57942998ab214c062e7a57220a174aacd80418cead9f90ec410eacada1',
+            HexBytes('0x10c7cb57942998ab214c062e7a57220a174aacd80418cead9f90ec410eacada1'),
         ),
         (
             # Intentionally sneaky: message is a hexstr interpreted as text
             '0x4d6573736167652074c3b6207369676e2e204c6f6e676572207468616e206861736821',
-            '0x6192785e9ad00100e7332ff585824b65eafa30bc8f1265cf86b5368aa3ab5d56',
+            HexBytes('0x6192785e9ad00100e7332ff585824b65eafa30bc8f1265cf86b5368aa3ab5d56'),
         ),
         (
             'Hello World',
-            '0xa1de988600a42c4b4ab089b619297c17d53cffae5d5120d82d8a92d0bb3b78f2',
+            HexBytes('0xa1de988600a42c4b4ab089b619297c17d53cffae5d5120d82d8a92d0bb3b78f2'),
         ),
     ]
 )
@@ -218,11 +219,11 @@ def test_eth_account_hash_message_text(web3, message, expected):
     [
         (
             '0x4d6573736167652074c3b6207369676e2e204c6f6e676572207468616e206861736821',
-            '0x10c7cb57942998ab214c062e7a57220a174aacd80418cead9f90ec410eacada1',
+            HexBytes('0x10c7cb57942998ab214c062e7a57220a174aacd80418cead9f90ec410eacada1'),
         ),
         (
             '0x29d9f7d6a1d1e62152f314f04e6bd4300ad56fd72102b6b83702869a089f470c',
-            '0xe709159ef0e6323c705786fc50e47a8143812e9f82f429e585034777c7bf530b',
+            HexBytes('0xe709159ef0e6323c705786fc50e47a8143812e9f82f429e585034777c7bf530b'),
         ),
     ]
 )
@@ -237,11 +238,11 @@ def test_eth_account_hash_message_hexstr(web3, message, expected):
             'Some data',
             '0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318',
             b'Some data',
-            '0x1da44b586eb0729ff70a73c326926f6ed5a25f5b056e7f47fbc6e58d86871655',
+            HexBytes('0x1da44b586eb0729ff70a73c326926f6ed5a25f5b056e7f47fbc6e58d86871655'),
             28,
-            '0xb91467e570a6466aa9e9876cbcd013baba02900b8979d43fe208a4a4f339f5fd',
-            '0x6007e74cd82e037b800186422fc2da167c747ef045e5d18a5f5d4300f8e1a029',
-            '0xb91467e570a6466aa9e9876cbcd013baba02900b8979d43fe208a4a4f339f5fd6007e74cd82e037b800186422fc2da167c747ef045e5d18a5f5d4300f8e1a0291c',  # noqa: E501
+            HexBytes('0xb91467e570a6466aa9e9876cbcd013baba02900b8979d43fe208a4a4f339f5fd'),
+            HexBytes('0x6007e74cd82e037b800186422fc2da167c747ef045e5d18a5f5d4300f8e1a029'),
+            HexBytes('0xb91467e570a6466aa9e9876cbcd013baba02900b8979d43fe208a4a4f339f5fd6007e74cd82e037b800186422fc2da167c747ef045e5d18a5f5d4300f8e1a0291c'),  # noqa: E501
         ),
     ),
 )
@@ -271,10 +272,10 @@ def test_eth_account_sign(web3, message, key, expected_bytes, expected_hash, v, 
                 'chainId': 1
             },
             '0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318',
-            '0xf86a8086d55698372431831e848094f0109fc8df283027b6285cc889f5aa624eac1f55843b9aca008025a009ebb6ca057a0535d6186462bc0b465b561c94a295bdb0621fc19208ab149a9ca0440ffd775ce91a833ab410777204d5341a6f9fa91216a6f3ee2c051fea6a0428',  # noqa: E501
-            '0x6893a6ee8df79b0f5d64a180cd1ef35d030f3e296a5361cf04d02ce720d32ec5',
-            '0x09ebb6ca057a0535d6186462bc0b465b561c94a295bdb0621fc19208ab149a9c',
-            '0x440ffd775ce91a833ab410777204d5341a6f9fa91216a6f3ee2c051fea6a0428',
+            HexBytes('0xf86a8086d55698372431831e848094f0109fc8df283027b6285cc889f5aa624eac1f55843b9aca008025a009ebb6ca057a0535d6186462bc0b465b561c94a295bdb0621fc19208ab149a9ca0440ffd775ce91a833ab410777204d5341a6f9fa91216a6f3ee2c051fea6a0428'),  # noqa: E501
+            HexBytes('0x6893a6ee8df79b0f5d64a180cd1ef35d030f3e296a5361cf04d02ce720d32ec5'),
+            HexBytes('0x09ebb6ca057a0535d6186462bc0b465b561c94a295bdb0621fc19208ab149a9c'),
+            HexBytes('0x440ffd775ce91a833ab410777204d5341a6f9fa91216a6f3ee2c051fea6a0428'),
             37,
         ),
     ),
@@ -305,7 +306,7 @@ def test_eth_account_sign_transaction_from_eth_test(web3, transaction):
     # author's ignorance. The example test fixtures and implementations seem to agree, so far.
     # See ecdsa_raw_sign() in /eth_keys/backends/native/ecdsa.py
     signed = web3.eth.account.signTransaction(transaction, key)
-    assert signed.r == '0x' + expected_raw_txn[-130:-66]
+    assert signed.r == HexBytes(expected_raw_txn[-130:-66])
 
     # confirm that signed transaction can be recovered to the sender
     expected_sender = web3.eth.account.privateKeyToAccount(key).address

--- a/tests/core/utilities/test_encoding.py
+++ b/tests/core/utilities/test_encoding.py
@@ -3,7 +3,6 @@
 from __future__ import unicode_literals
 
 import pytest
-import re
 import sys
 
 from eth_utils import (
@@ -25,6 +24,10 @@ from web3.utils.encoding import (
     to_hex,
 )
 
+from web3.utils.hypothesis import (
+    hexstr_strategy,
+)
+
 # Several tests are split into py2 & py3 tests below, with py3 tests using Mock
 if sys.version_info.major > 2:
     from unittest.mock import Mock
@@ -37,8 +40,6 @@ only_python3 = pytest.mark.skipif(
     sys.version_info.major < 3,
     reason="these test values only valid for py3"
 )
-
-HEX_REGEX = re.compile('\A(0[xX])?[0-9a-fA-F]*\Z')
 
 
 @pytest.mark.parametrize(
@@ -119,7 +120,7 @@ def test_hexstr_if_str_passthrough_py2(val, converter):
 
 @only_python2
 @given(
-    st.from_regex(HEX_REGEX),
+    hexstr_strategy(),
     st.sampled_from((to_bytes, to_hex, to_decimal)),
 )
 def test_hexstr_if_str_valid_hex_py2(val, converter):
@@ -161,7 +162,7 @@ def test_hexstr_if_str_curried():
 
 
 @only_python3
-@given(st.from_regex(HEX_REGEX))
+@given(hexstr_strategy())
 @example('0x')
 @example('0')
 def test_hexstr_if_str_on_valid_hex(val):

--- a/tests/core/utilities/test_hexbytes.py
+++ b/tests/core/utilities/test_hexbytes.py
@@ -1,0 +1,22 @@
+from hypothesis import (
+    given,
+    strategies as st,
+)
+
+from web3.utils.datastructures import HexBytes
+
+from web3.utils.encoding import (
+    to_bytes,
+)
+
+from web3.utils.hypothesis import hexstr_strategy
+
+
+@given(st.binary())
+def test_hexbytes_equals_bytes(bytesval):
+    assert HexBytes(bytesval) == bytesval
+
+
+@given(hexstr_strategy())
+def test_hexbytes_hexstr_to_bytes(hexstr):
+    assert HexBytes(hexstr) == to_bytes(hexstr=hexstr)

--- a/web3/account.py
+++ b/web3/account.py
@@ -30,6 +30,7 @@ from eth_utils import (
 
 from web3.utils.datastructures import (
     AttributeDict,
+    HexBytes,
 )
 from web3.utils.encoding import (
     hexstr_if_str,
@@ -37,7 +38,6 @@ from web3.utils.encoding import (
     to_bytes,
     to_decimal,
     to_hex,
-    to_hex_with_size,
 )
 from web3.utils.exception import (
     raise_from,
@@ -81,7 +81,7 @@ class Account(object):
 
     @staticmethod
     def encrypt(private_key, password):
-        key_bytes = hexstr_if_str(to_bytes, private_key)
+        key_bytes = HexBytes(private_key)
         password_bytes = text_if_str(to_bytes, password)
         assert len(key_bytes) == 32
         return create_keyfile_json(key_bytes, password_bytes)
@@ -89,11 +89,11 @@ class Account(object):
     @staticmethod
     def hashMessage(data=None, hexstr=None, text=None):
         message_bytes = to_bytes(data, hexstr=hexstr, text=text)
-        recovery_hasher = compose(to_hex, keccak, signature_wrapper)
+        recovery_hasher = compose(HexBytes, keccak, signature_wrapper)
         return recovery_hasher(message_bytes)
 
     def privateKeyToAccount(self, private_key):
-        key_bytes = hexstr_if_str(to_bytes, private_key)
+        key_bytes = HexBytes(private_key)
         try:
             key_obj = self._keys.PrivateKey(key_bytes)
             return LocalAccount(key_obj, self)
@@ -107,13 +107,13 @@ class Account(object):
             )
 
     def recover(self, msghash, vrs=None, signature=None):
-        hash_bytes = hexstr_if_str(to_bytes, msghash)
+        hash_bytes = HexBytes(msghash)
         if vrs is not None:
             v, r, s = map(hexstr_if_str(to_decimal), vrs)
             v_standard = to_standard_v(v)
             signature_obj = self._keys.Signature(vrs=(v_standard, r, s))
         elif signature is not None:
-            signature_bytes = hexstr_if_str(to_bytes, signature)
+            signature_bytes = HexBytes(signature)
             signature_bytes_standard = to_standard_signature_bytes(signature_bytes)
             signature_obj = self._keys.Signature(signature_bytes=signature_bytes_standard)
         else:
@@ -126,7 +126,7 @@ class Account(object):
         return self.recover(msg_hash, vrs=vrs, signature=signature)
 
     def recoverTransaction(self, serialized_transaction):
-        txn_bytes = hexstr_if_str(to_bytes, serialized_transaction)
+        txn_bytes = HexBytes(serialized_transaction)
         txn = Transaction.from_bytes(txn_bytes)
         msg_hash = hash_of_signed_transaction(txn)
         if sys.version_info.major < 3:
@@ -144,17 +144,16 @@ class Account(object):
         '''
         msg_bytes = to_bytes(message, hexstr=message_hexstr, text=message_text)
         msg_hash = self.hashMessage(msg_bytes)
-        key_bytes = hexstr_if_str(to_bytes, private_key)
+        key_bytes = HexBytes(private_key)
         key = self._keys.PrivateKey(key_bytes)
         (v, r, s, eth_signature_bytes) = sign_message_hash(key, msg_hash)
-        (r_hex, s_hex, eth_signature_hex) = map(to_hex, (r, s, eth_signature_bytes))
         return AttributeDict({
-            'message': msg_bytes,
+            'message': HexBytes(msg_bytes),
             'messageHash': msg_hash,
-            'r': r_hex,
-            's': s_hex,
+            'r': HexBytes(r),
+            's': HexBytes(s),
             'v': v,
-            'signature': eth_signature_hex,
+            'signature': HexBytes(eth_signature_bytes),
         })
 
     def signTransaction(self, transaction_dict, private_key):
@@ -176,16 +175,10 @@ class Account(object):
             rlp_encoded,
         ) = sign_transaction_dict(account._key_obj, transaction_dict)
 
-        # format most returned elements as hex
-        signature_info = {
-            key: to_hex_with_size(val, 256)  # minimum size is 32 bytes
-            for key, val
-            in (
-                ('rawTransaction', rlp_encoded),
-                ('hash', transaction_hash),
-                ('r', r),
-                ('s', s),
-            )
-        }
-        signature_info['v'] = v
-        return AttributeDict(signature_info)
+        return AttributeDict({
+            'rawTransaction': HexBytes(rlp_encoded),
+            'hash': HexBytes(transaction_hash),
+            'r': HexBytes(r),
+            's': HexBytes(s),
+            'v': v,
+        })

--- a/web3/providers/ipc.py
+++ b/web3/providers/ipc.py
@@ -46,7 +46,7 @@ class PersistantSocket(object):
         if exc_value is not None:
             try:
                 self.sock.close()
-            except:
+            except Exception:
                 pass
             self.sock = None
 

--- a/web3/utils/datastructures.py
+++ b/web3/utils/datastructures.py
@@ -7,6 +7,11 @@ from collections import (
     Sequence,
 )
 
+from web3.utils.encoding import (
+    hexstr_if_str,
+    to_bytes,
+)
+
 from web3.utils.formatters import recursive_map
 
 # Hashable must be immutable:
@@ -168,3 +173,18 @@ class NamedElementStack(Mapping):
         if not isinstance(elements, Sequence):
             elements = list(elements)
         return iter(elements)
+
+
+class HexBytes(bytes):
+    def __new__(cls, val):
+        bytesval = hexstr_if_str(to_bytes, val)
+        return super().__new__(cls, bytesval)
+
+    def __init__(self, val):
+        super().__init__()
+
+    def hex(self):
+        return '0x' + super().hex()
+
+    def __repr__(self):
+        return 'HexBytes(%r)' % self.hex()

--- a/web3/utils/datastructures.py
+++ b/web3/utils/datastructures.py
@@ -180,9 +180,6 @@ class HexBytes(bytes):
         bytesval = hexstr_if_str(to_bytes, val)
         return super().__new__(cls, bytesval)
 
-    def __init__(self, val):
-        super().__init__()
-
     def hex(self):
         return '0x' + super().hex()
 

--- a/web3/utils/hypothesis.py
+++ b/web3/utils/hypothesis.py
@@ -1,0 +1,7 @@
+from hypothesis import (
+    strategies as st,
+)
+
+
+def hexstr_strategy():
+    return st.from_regex('\A(0[xX])?[0-9a-fA-F]*\Z')

--- a/web3/utils/signing.py
+++ b/web3/utils/signing.py
@@ -121,8 +121,8 @@ def sign_transaction_hash(account, transaction_hash, chain_id):
     return (v, r, s)
 
 
-def sign_message_hash(key, msg_hash_hex):
-    signature = key.sign_msg_hash(to_bytes(hexstr=msg_hash_hex))
+def sign_message_hash(key, msg_hash):
+    signature = key.sign_msg_hash(msg_hash)
     (v_standard, r, s) = signature.vrs
     v = v_standard + V_OFFSET
     eth_signature_bytes = b''.join(map(to_bytes, (r, s, v)))


### PR DESCRIPTION
### What was wrong?

`web3.eth.account` is returning hex strings where a bytes-like value would be more appropriate (see #340 for further rationale)

This is a test-run for changing all the values in #340 -- if it looks good, I'll apply this approach to the other methods.

### How was it fixed?

Return bytes instead of hex strings for `sign()`, `signTransaction()`, and `hashMessage()`. Unfortunately, the output was so ugly that I was embarrassed to put it in the docs.

So I also created a new `HexBytes` class that is just like `bytes` (and tests == to `bytes` natively), but has a prettier display.

Key Features:

```py
>>> assert HexBytes('0xaf') == b'\xaf'
>>> HexBytes('0xaf')
HexBytes('0xaf')
```

#### Cute Animal Picture

![Cute animal picture](https://i.pinimg.com/originals/43/3d/27/433d274ffcea0faccfd68a6358d4bedc.jpg)