### PR TITLE
[v4] remove deprecated toDecimal features, and a better name

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -135,26 +135,26 @@ Type Conversions
         b'cowm\xc3\xb6'
 
 
-.. py:method:: Web3.toDecimal(primitive=None, hexstr=None, text=None)
+.. py:method:: Web3.toInt(primitive=None, hexstr=None, text=None)
 
-    Takes a variety of inputs and returns its int equivalent.
+    Takes a variety of inputs and returns its integer equivalent.
 
 
     .. code-block:: python
 
-        >>> Web3.toDecimal(0)
+        >>> Web3.toInt(0)
         0
-        >>> Web3.toDecimal(0x000F)
+        >>> Web3.toInt(0x000F)
         15
-        >>> Web3.toDecimal(b'\x00\x0F')
+        >>> Web3.toInt(b'\x00\x0F')
         15
-        >>> Web3.toDecimal(False)
+        >>> Web3.toInt(False)
         0
-        >>> Web3.toDecimal(True)
+        >>> Web3.toInt(True)
         1
-        >>> Web3.toDecimal(hexstr='0x000F')
+        >>> Web3.toInt(hexstr='0x000F')
         15
-        >>> Web3.toDecimal(hexstr='000F')
+        >>> Web3.toInt(hexstr='000F')
         15
 
 .. _overview_currency_conversions:

--- a/tests/core/utilities/test_encoding.py
+++ b/tests/core/utilities/test_encoding.py
@@ -20,7 +20,7 @@ from web3.utils.encoding import (
     text_if_str,
     hexstr_if_str,
     to_bytes,
-    to_decimal,
+    to_int,
     to_hex,
 )
 
@@ -60,7 +60,7 @@ def test_to_hex(value, expected):
 @given(value=st.integers(min_value=-1 * 2**255 + 1, max_value=2**256 - 1))
 def test_conversion_round_trip(value):
     intermediate_value = to_hex(value)
-    result_value = to_decimal(hexstr=intermediate_value)
+    result_value = to_int(hexstr=intermediate_value)
     error_msg = "Expected: {0!r}, Result: {1!r}, Intermediate: {2!r}".format(
         value,
         result_value,
@@ -112,7 +112,7 @@ def test_hex_encode_abi_type(abi_type, value, expected):
 @only_python2
 @given(
     st.one_of(st.integers(min_value=0), st.booleans()),
-    st.sampled_from((to_bytes, to_hex, to_decimal)),
+    st.sampled_from((to_bytes, to_hex, to_int)),
 )
 def test_hexstr_if_str_passthrough_py2(val, converter):
     assert hexstr_if_str(converter, val) == converter(val)
@@ -121,10 +121,10 @@ def test_hexstr_if_str_passthrough_py2(val, converter):
 @only_python2
 @given(
     hexstr_strategy(),
-    st.sampled_from((to_bytes, to_hex, to_decimal)),
+    st.sampled_from((to_bytes, to_hex, to_int)),
 )
 def test_hexstr_if_str_valid_hex_py2(val, converter):
-    if converter is to_decimal and to_bytes(hexstr=val) == b'':
+    if converter is to_int and to_bytes(hexstr=val) == b'':
         with pytest.raises(ValueError):
             hexstr_if_str(converter, val)
     else:
@@ -134,7 +134,7 @@ def test_hexstr_if_str_valid_hex_py2(val, converter):
 @only_python2
 @given(
     st.one_of(st.text(), st.binary()),
-    st.sampled_from((to_bytes, to_hex, to_decimal)),
+    st.sampled_from((to_bytes, to_hex, to_int)),
 )
 def test_hexstr_if_str_invalid_hex_py2(val, converter):
     try:
@@ -210,7 +210,7 @@ def test_text_if_str_on_text(val):
 @example(b'', to_hex)
 @example(b'\xff', to_bytes)  # bytes are passed through, no matter the text
 def test_text_if_str_passthrough_py2(val, converter):
-    if converter is to_decimal and to_bytes(val) == b'':
+    if converter is to_int and to_bytes(val) == b'':
         with pytest.raises(ValueError):
             text_if_str(converter, val)
     else:
@@ -229,5 +229,5 @@ def test_text_if_str_on_text_py2(val, converter):
 
 @only_python2
 @given(st.from_regex('\A[0-9]+\Z'))
-def test_text_if_str_on_text_to_decimal_py2(val):
-    assert text_if_str(to_decimal, val) == to_decimal(text=val)
+def test_text_if_str_on_text_to_int_py2(val):
+    assert text_if_str(to_int, val) == to_int(text=val)

--- a/tests/core/web3-module/test_conversions.py
+++ b/tests/core/web3-module/test_conversions.py
@@ -32,7 +32,7 @@ def test_to_bytes_long():
     minlong = sys.maxint + 1
     assert minlong > sys.maxint  # are there any python interpreters that overflow?
     valbytes = Web3.toBytes(minlong)
-    assert Web3.toDecimal(valbytes) == minlong
+    assert Web3.toInt(valbytes) == minlong
 
 
 @pytest.mark.parametrize(
@@ -115,20 +115,20 @@ def test_to_text_hexstr(val, expected):
         (b'\x01', 1),
         (b'\x00\x01', 1),
         (b'\x01\x00', 256),
-        ('255', 255),
-        ('-1', -1),
         (True, 1),
         (False, 0),
-        ('0x0', ValueError),
-        ('0x1', ValueError),
+        ('255', TypeError),
+        ('-1', TypeError),
+        ('0x0', TypeError),
+        ('0x1', TypeError),
     )
 )
-def test_to_decimal(val, expected):
+def test_to_int(val, expected):
     if isinstance(expected, type):
         with pytest.raises(expected):
-            Web3.toDecimal(val)
+            Web3.toInt(val)
     else:
-        assert Web3.toDecimal(val) == expected
+        assert Web3.toInt(val) == expected
 
 
 @pytest.mark.parametrize(
@@ -137,12 +137,18 @@ def test_to_decimal(val, expected):
         ('0', 0),
         ('-1', -1),
         ('255', 255),
+        ('0x0', ValueError),
+        ('0x1', ValueError),
+        ('1.1', ValueError),
+        ('a', ValueError),
     )
 )
-def test_to_decimal_text(val, expected):
-    if isinstance(val, bytes) and bytes == str:
-        pytest.skip("Python 3 is required to pass in bytes")
-    assert Web3.toDecimal(text=val) == expected
+def test_to_int_text(val, expected):
+    if isinstance(expected, type):
+        with pytest.raises(expected):
+            Web3.toInt(text=val)
+    else:
+        assert Web3.toInt(text=val) == expected
 
 
 @pytest.mark.parametrize(
@@ -158,8 +164,8 @@ def test_to_decimal_text(val, expected):
         ('10', 16),
     )
 )
-def test_to_decimal_hexstr(val, expected):
-    assert Web3.toDecimal(hexstr=val) == expected
+def test_to_int_hexstr(val, expected):
+    assert Web3.toInt(hexstr=val) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/core/web3-module/test_conversions.py
+++ b/tests/core/web3-module/test_conversions.py
@@ -119,15 +119,16 @@ def test_to_text_hexstr(val, expected):
         ('-1', -1),
         (True, 1),
         (False, 0),
-        # Deprecated:
-        ('0x0', 0),
-        ('0x1', 1),
-        ('0x01', 1),
-        ('0x10', 16),
+        ('0x0', ValueError),
+        ('0x1', ValueError),
     )
 )
 def test_to_decimal(val, expected):
-    assert Web3.toDecimal(val) == expected
+    if isinstance(expected, type):
+        with pytest.raises(expected):
+            Web3.toDecimal(val)
+    else:
+        assert Web3.toDecimal(val) == expected
 
 
 @pytest.mark.parametrize(

--- a/web3/account.py
+++ b/web3/account.py
@@ -36,7 +36,7 @@ from web3.utils.encoding import (
     hexstr_if_str,
     text_if_str,
     to_bytes,
-    to_decimal,
+    to_int,
     to_hex,
 )
 from web3.utils.exception import (
@@ -109,7 +109,7 @@ class Account(object):
     def recover(self, msghash, vrs=None, signature=None):
         hash_bytes = HexBytes(msghash)
         if vrs is not None:
-            v, r, s = map(hexstr_if_str(to_decimal), vrs)
+            v, r, s = map(hexstr_if_str(to_int), vrs)
             v_standard = to_standard_v(v)
             signature_obj = self._keys.Signature(vrs=(v_standard, r, s))
         elif signature is not None:

--- a/web3/main.py
+++ b/web3/main.py
@@ -8,7 +8,6 @@ from eth_utils import (
     add_0x_prefix,
     decode_hex,
     encode_hex,
-    force_text,
     from_wei,
     is_address,
     is_checksum_address,
@@ -51,10 +50,9 @@ from web3.utils.decorators import (
     deprecated_for,
 )
 from web3.utils.encoding import (
-    from_decimal,
     hex_encode_abi_type,
     to_bytes,
-    to_decimal,
+    to_int,
     to_hex,
     to_text,
 )
@@ -92,7 +90,7 @@ class Web3(object):
 
     # Encoding and Decoding
     toBytes = staticmethod(to_bytes)
-    toDecimal = staticmethod(to_decimal)
+    toInt = staticmethod(to_int)
     toHex = staticmethod(to_hex)
     toText = staticmethod(to_text)
 
@@ -228,28 +226,3 @@ class Web3(object):
                 return True
         else:
             return False
-
-    @staticmethod
-    @deprecated_for("toBytes()")
-    def toAscii(val):
-        return decode_hex(val)
-
-    @staticmethod
-    @deprecated_for("toHex()")
-    def fromAscii(val):
-        return encode_hex(val)
-
-    @staticmethod
-    @deprecated_for("toText()")
-    def toUtf8(val):
-        return force_text(decode_hex(val))
-
-    @staticmethod
-    @deprecated_for("toHex()")
-    def fromUtf8(string):
-        return encode_hex(string)
-
-    @staticmethod
-    @deprecated_for("toHex()")
-    def fromDecimal(decimal):
-        return from_decimal(decimal)

--- a/web3/utils/encoding.py
+++ b/web3/utils/encoding.py
@@ -2,7 +2,6 @@
 import json
 import re
 import sys
-import warnings
 
 import rlp
 from rlp.sedes import big_endian_int
@@ -173,19 +172,10 @@ def to_decimal(value=None, hexstr=None, text=None):
     elif text is not None:
         return int(text)
     elif is_string(value):
-        if bytes != str and isinstance(value, bytes):
+        if isinstance(value, bytes):
             return to_decimal(hexstr=to_hex(value))
-        elif is_0x_prefixed(value) or _is_prefixed(value, '-0x'):
-            warnings.warn(DeprecationWarning(
-                "Sending a hex string in the first position has been deprecated. Please use "
-                "toDecimal(hexstr='%s') instead." % value
-            ))
-            return to_decimal(hexstr=value)
         else:
-            try:
-                return int(value)
-            except ValueError:
-                return to_decimal(hexstr=to_hex(value))
+            return int(value)
     else:
         return int(value)
 

--- a/web3/utils/encoding.py
+++ b/web3/utils/encoding.py
@@ -12,11 +12,11 @@ from cytoolz import (
 
 from eth_utils import (
     add_0x_prefix,
+    big_endian_to_int,
     coerce_args_to_bytes,
     force_bytes,
     force_text,
     int_to_big_endian,
-    is_0x_prefixed,
     is_boolean,
     is_bytes,
     is_dict,
@@ -39,9 +39,6 @@ from web3.utils.abi import (
     is_string_type,
     size_of_type,
     sub_type_of_array_type,
-)
-from web3.utils.decorators import (
-    deprecated_for,
 )
 from web3.utils.validation import (
     assert_one_val,
@@ -161,9 +158,17 @@ def to_hex(value=None, hexstr=None, text=None):
     )
 
 
-def to_decimal(value=None, hexstr=None, text=None):
+def to_int(value=None, hexstr=None, text=None):
     """
-    Converts value to it's decimal representation in string
+    Converts value to it's integer representation.
+
+    Values are converted this way:
+
+     * value:
+       * bytes: big-endian integer
+       * bool: True => 1, False => 0
+     * hexstr: interpret hex as integer
+     * text: interpret as string of digits, like '12' => 12
     """
     assert_one_val(value, hexstr=hexstr, text=text)
 
@@ -171,27 +176,12 @@ def to_decimal(value=None, hexstr=None, text=None):
         return int(hexstr, 16)
     elif text is not None:
         return int(text)
-    elif is_string(value):
-        if isinstance(value, bytes):
-            return to_decimal(hexstr=to_hex(value))
-        else:
-            return int(value)
+    elif isinstance(value, bytes):
+        return big_endian_to_int(value)
+    elif isinstance(value, str):
+        raise TypeError("Pass in strings with keyword hexstr or text")
     else:
         return int(value)
-
-
-@deprecated_for("to_hex")
-def from_decimal(value):
-    """
-    Converts numeric value to its hex representation
-    """
-    if is_string(value):
-        if is_0x_prefixed(value) or _is_prefixed(value, '-0x'):
-            value = int(value, 16)
-        else:
-            value = int(value)
-
-    return to_hex(value)
 
 
 def to_bytes(primitive=None, hexstr=None, text=None):
@@ -240,7 +230,7 @@ def text_if_str(to_type, text_or_primitive):
     Convert to a type, assuming that strings can be only unicode text (not a hexstr)
 
     @param to_type is a function that takes the arguments (primitive, hexstr=hexstr, text=text),
-        eg~ to_bytes, to_text, to_hex, to_decimal, etc
+        eg~ to_bytes, to_text, to_hex, to_int, etc
     @param hexstr_or_primitive in bytes, str, or int. (or unicode in py2)
         In Python 2, only a unicode object will be interpreted as unicode text
         In Python 3, only a str object will be interpreted as interpreted as unicode text
@@ -263,7 +253,7 @@ def hexstr_if_str(to_type, hexstr_or_primitive):
     Convert to a type, assuming that strings can be only hexstr (not unicode text)
 
     @param to_type is a function that takes the arguments (primitive, hexstr=hexstr, text=text),
-        eg~ to_bytes, to_text, to_hex, to_decimal, etc
+        eg~ to_bytes, to_text, to_hex, to_int, etc
     @param text_or_primitive in bytes, str, or int. (or unicode in py2)
         In Python 2, a bytes, unicode or str object will be interpreted as hexstr
         In Python 3, only a str object will be interpreted as hexstr

--- a/web3/utils/signing.py
+++ b/web3/utils/signing.py
@@ -3,7 +3,7 @@ import sys
 
 from web3.utils.encoding import (
     to_bytes,
-    to_decimal,
+    to_int,
     to_hex,
 )
 
@@ -99,7 +99,7 @@ def extract_chain_id(raw_v):
 
 def to_standard_signature_bytes(ethereum_signature_bytes):
     rs = ethereum_signature_bytes[:-1]
-    v = to_decimal(ethereum_signature_bytes[-1])
+    v = to_int(ethereum_signature_bytes[-1])
     standard_v = to_standard_v(v)
     return rs + to_bytes(standard_v)
 

--- a/web3/utils/transactions.py
+++ b/web3/utils/transactions.py
@@ -25,7 +25,7 @@ from web3.utils.compat import (
 from web3.utils.encoding import (
     ExtendedRLP,
     hexstr_if_str,
-    to_decimal,
+    to_int,
 )
 from web3.utils.formatters import (
     apply_formatter_if,
@@ -66,15 +66,15 @@ TRANSACTION_DEFAULTS = {
 }
 
 TRANSACTION_FORMATTERS = {
-    'nonce': hexstr_if_str(to_decimal),
-    'gasPrice': hexstr_if_str(to_decimal),
-    'gas': hexstr_if_str(to_decimal),
+    'nonce': hexstr_if_str(to_int),
+    'gasPrice': hexstr_if_str(to_int),
+    'gas': hexstr_if_str(to_int),
     'to': apply_formatter_if(decode_hex, is_string),
-    'value': hexstr_if_str(to_decimal),
+    'value': hexstr_if_str(to_int),
     'data': apply_formatter_if(decode_hex, is_string),
-    'v': hexstr_if_str(to_decimal),
-    'r': hexstr_if_str(to_decimal),
-    's': hexstr_if_str(to_decimal),
+    'v': hexstr_if_str(to_int),
+    'r': hexstr_if_str(to_int),
+    's': hexstr_if_str(to_int),
 }
 
 


### PR DESCRIPTION
### What was wrong?

#341 toDecimal has old deprecated functionality, marked deprecated: it accepted a string as a primitive value and tried to distinguish between hex and integer strings.

Also, the name is confusing, because it's really an `int`, not a `decimal.Decimal`.

### How was it fixed?

Removed deprecated functionality, and switched to `toInt()` as a more natural name.

#### Cute Animal Picture

![Cute animal picture](https://i.pinimg.com/736x/5f/48/d9/5f48d9194d7c1ee2df6efb8e7308347c--identity-theft-dutch-rabbit.jpg)
