### PR TITLE
remove deprecated block_with_txn_with_log

### DIFF
--- a/tests/integration/test_ethtestrpc.py
+++ b/tests/integration/test_ethtestrpc.py
@@ -119,12 +119,6 @@ def funded_account_for_raw_txn(web3):
     return account
 
 
-@pytest.fixture(scope="session")
-def block_with_txn_with_log():
-    # skip any tests that need this for now since it's deprecated.
-    pytest.skip()
-
-
 class TestEthTestRPCWeb3Module(Web3ModuleTest):
     def _check_web3_clientVersion(self, client_version):
         assert client_version.startswith('TestRPC/')

--- a/web3/utils/module_testing/eth_module.py
+++ b/web3/utils/module_testing/eth_module.py
@@ -296,28 +296,6 @@ class EthModuleTest(object):
         receipt = web3.eth.getTransactionReceipt(txn_hash)
         assert receipt is None
 
-    def test_eth_getTransactionReceipt_with_log_entry(self,
-                                                      web3,
-                                                      block_with_txn_with_log,
-                                                      emitter_contract,
-                                                      txn_hash_with_log):
-        receipt = web3.eth.getTransactionReceipt(txn_hash_with_log)
-        assert is_dict(receipt)
-        assert receipt['blockNumber'] == block_with_txn_with_log['number']
-        assert receipt['blockHash'] == block_with_txn_with_log['hash']
-        assert receipt['transactionIndex'] == 0
-        assert receipt['transactionHash'] == txn_hash_with_log
-
-        assert len(receipt['logs']) == 1
-        log_entry = receipt['logs'][0]
-
-        assert log_entry['blockNumber'] == block_with_txn_with_log['number']
-        assert log_entry['blockHash'] == block_with_txn_with_log['hash']
-        assert log_entry['logIndex'] == 0
-        assert is_same_address(log_entry['address'], emitter_contract.address)
-        assert log_entry['transactionIndex'] == 0
-        assert log_entry['transactionHash'] == txn_hash_with_log
-
     def test_eth_getUncleByBlockHashAndIndex(self, web3):
         # TODO: how do we make uncles....
         pass


### PR DESCRIPTION
### What was wrong?

This was marked deprecated. I'm not sure why. #341 

### How was it fixed?

Removed the test that depended on it (and was being skipped).

I'm taking an ax to everything marked deprecated.

#### Cute Animal Picture

![Cute animal picture](https://i.pinimg.com/originals/f8/75/2e/f8752e06e655c2b358341a80850b1329.jpg)
