### PR TITLE
Remove deprecated middleware calls

### DIFF
--- a/web3/main.py
+++ b/web3/main.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import sys
 import warnings
 
 from eth_utils import (
@@ -106,8 +105,6 @@ class Web3(object):
     toChecksumAddress = staticmethod(to_checksum_address)
 
     def __init__(self, providers, middlewares=None, modules=None):
-        self._deprecation_warn()
-
         self.manager = RequestManager(self, providers, middlewares)
 
         if modules is None:
@@ -115,16 +112,6 @@ class Web3(object):
 
         for module_name, module_class in modules.items():
             module_class.attach(self, module_name)
-
-    def _deprecation_warn(self):
-        if sys.version_info.major < 3:
-            warnings.simplefilter('always', DeprecationWarning)
-            warnings.warn(
-                "Python 2 support is ending! Please upgrade to Python 3 promptly."
-                " Support will end at the beginning of 2018.",
-                category=DeprecationWarning,
-            )
-            warnings.simplefilter('default', DeprecationWarning)
 
     @property
     def middleware_stack(self):

--- a/web3/main.py
+++ b/web3/main.py
@@ -130,14 +130,6 @@ class Web3(object):
     def middleware_stack(self):
         return self.manager.middleware_stack
 
-    @deprecated_for("Web3.middleware_stack.add(middleware [, name])")
-    def add_middleware(self, middleware, name=None):
-        return self.middleware_stack.add(middleware, name=name)
-
-    @deprecated_for("Web3.middleware_stack.clear()")
-    def clear_middlewares(self):
-        return self.middleware_stack.clear()
-
     @property
     def providers(self):
         return self.manager.providers

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -20,9 +20,6 @@ from web3.utils.compat import (
 from web3.utils.datastructures import (
     NamedElementStack,
 )
-from web3.utils.decorators import (
-    deprecated_for,
-)
 
 
 class RequestManager(object):
@@ -38,14 +35,6 @@ class RequestManager(object):
 
     web3 = None
     _providers = None
-
-    @deprecated_for("manager.middleware_stack.add(middleware [, name])")
-    def add_middleware(self, middleware):
-        return self.middleware_stack.add(middleware)
-
-    @deprecated_for("manager.middleware_stack.clear()")
-    def clear_middlewares(self):
-        return self.middleware_stack.clear()
 
     @property
     def providers(self):


### PR DESCRIPTION
### What was wrong?

Deprecated middleware calls are still around #341 

### How was it fixed?

Remove deprecated calls

Also includes removal of Py3 warning, since this code will only run on py3.

#### Cute Animal Picture

![Cute animal picture](http://bungalowofbunnies.weebly.com/uploads/1/9/4/9/19499657/8355453_orig.jpg)
