### PR TITLE
personal: remove deprecated method & argument

### DIFF
--- a/docs/web3.personal.rst
+++ b/docs/web3.personal.rst
@@ -44,7 +44,7 @@ The following methods are available on the ``web3.personal`` namespace.
         ['0xd3cda913deb6f67967b99d67acdfa1712c293601']
 
 
-.. py:method:: newAccount(self, password=None)
+.. py:method:: newAccount(self, password)
 
     * Delegates to ``personal_newAccount`` RPC Method
 
@@ -55,23 +55,6 @@ The following methods are available on the ``web3.personal`` namespace.
 
         >>> web3.personal.newAccount('the-passphrase')
         ['0xd3cda913deb6f67967b99d67acdfa1712c293601']
-
-
-.. py:method:: signAndSendTransaction(self, tx, passphrase)
-
-    * Delegates to ``personal_signAndSendTransaction`` RPC Method
-
-    Signs and sends the given ``transaction`` without requiring the ``from``
-    account to be unlocked.  ``passphrase`` must be the passphrase for the
-    ``from`` account for the provided ``transaction``.
-
-    Behaves in the same manner as
-    :py:method::`web3.eth.Eth.sendTransaction(transaction)`.
-
-    .. code-block:: python
-
-        >>> web3.personal.signAndSendTransaction({'to': '0xd3cda913deb6f67967b99d67acdfa1712c293601', 'from': web3.eth.coinbase, 'value': 12345}, 'the-passphrase')
-        '0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331'
 
 
 .. py:method:: lockAccount(self, account)

--- a/web3/personal.py
+++ b/web3/personal.py
@@ -1,8 +1,5 @@
 from __future__ import absolute_import
 
-import getpass
-import warnings
-
 from web3.module import (
     Module,
 )
@@ -34,22 +31,7 @@ class Personal(Module):
         )
 
     @coerce_return_to_text
-    def newAccount(self, password=None):
-        if password is None:
-            warnings.warn(DeprecationWarning(
-                "Prompting for a password has been deprecated.  Please update "
-                "your code to provide a password"
-            ))
-            password1 = getpass.getpass("Passphrase:")
-            password2 = getpass.getpass("Repeat passphrase:")
-            if password1 != password2:
-                raise ValueError("Passwords do not match")
-
-            password = password1
-
-        if not password:
-            raise ValueError("Cannot have an empty password")
-
+    def newAccount(self, password):
         return self.web3.manager.request_blocking(
             "personal_newAccount", [password],
         )
@@ -71,14 +53,6 @@ class Personal(Module):
             "personal_sendTransaction",
             [transaction, passphrase],
         )
-
-    def signAndSendTransaction(self, *args, **kwargs):
-        warnings.warn(DeprecationWarning(
-            "The `web3.personal.signAndSendTransaction` has been renamed to "
-            "`web3.personal.sendTransaction`.  Please update your code to use "
-            "the new method as this one will be removed in a subsequent release"
-        ))
-        return self.sendTransaction(*args, **kwargs)
 
     def lockAccount(self, account):
         return self.web3.manager.request_blocking(


### PR DESCRIPTION
### What was wrong?

deprecated personal module methods #341 

### How was it fixed?

* delete signAndSendTransaction
* remove ability to call newAccount with no password

#### Cute Animal Picture

He'll do you up a treat, mate.

![Cute animal picture](https://images.bunspace.com/static/bunpics/8066/269244.jpg)