### PR TITLE
Deprecate Web3.toDecimal for .toInt

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -137,24 +137,29 @@ Type Conversions
 
 .. py:method:: Web3.toDecimal(primitive=None, hexstr=None, text=None)
 
-    Takes a variety of inputs and returns its int equivalent.
+    .. attention::
+        Deprecated for Web3.toInt(), with the same functionality.
+
+.. py:method:: Web3.toInt(primitive=None, hexstr=None, text=None)
+
+    Takes a variety of inputs and returns its integer equivalent.
 
 
     .. code-block:: python
 
-        >>> Web3.toDecimal(0)
+        >>> Web3.toInt(0)
         0
-        >>> Web3.toDecimal(0x000F)
+        >>> Web3.toInt(0x000F)
         15
-        >>> Web3.toDecimal(b'\x00\x0F')
+        >>> Web3.toInt(b'\x00\x0F')
         15
-        >>> Web3.toDecimal(False)
+        >>> Web3.toInt(False)
         0
-        >>> Web3.toDecimal(True)
+        >>> Web3.toInt(True)
         1
-        >>> Web3.toDecimal(hexstr='0x000F')
+        >>> Web3.toInt(hexstr='0x000F')
         15
-        >>> Web3.toDecimal(hexstr='000F')
+        >>> Web3.toInt(hexstr='000F')
         15
 
 .. _overview_currency_conversions:

--- a/web3/main.py
+++ b/web3/main.py
@@ -56,6 +56,7 @@ from web3.utils.encoding import (
     to_bytes,
     to_decimal,
     to_hex,
+    to_int,
     to_text,
 )
 
@@ -92,9 +93,13 @@ class Web3(object):
 
     # Encoding and Decoding
     toBytes = staticmethod(to_bytes)
-    toDecimal = staticmethod(to_decimal)
     toHex = staticmethod(to_hex)
+    toInt = staticmethod(to_int)
     toText = staticmethod(to_text)
+
+    toDecimal = staticmethod(
+        deprecated_for("toInt()")(to_decimal)
+    )
 
     # Currency Utility
     toWei = staticmethod(to_wei)

--- a/web3/providers/ipc.py
+++ b/web3/providers/ipc.py
@@ -46,7 +46,7 @@ class PersistantSocket(object):
         if exc_value is not None:
             try:
                 self.sock.close()
-            except:
+            except Exception:
                 pass
             self.sock = None
 

--- a/web3/utils/encoding.py
+++ b/web3/utils/encoding.py
@@ -160,10 +160,15 @@ def to_hex(value=None, hexstr=None, text=None):
     )
 
 
+@deprecated_for("to_int")
 def to_decimal(value=None, hexstr=None, text=None):
     """
     Converts value to it's decimal representation in string
     """
+    return to_int(value, hexstr=hexstr, text=text)
+
+
+def to_int(value=None, hexstr=None, text=None):
     assert_one_val(value, hexstr=hexstr, text=text)
 
     if hexstr is not None:


### PR DESCRIPTION
### What was wrong?

toDecimal's name is confusing, but we want to give some warning to people who are using it in v3. It will be removed in v4 ( #367 ).

### How was it fixed?

Added a deprecation warning, and an alias of toInt on Web3 (plus docs)

#### Cute Animal Picture

He's got huge, sharp... er... He can leap about. Look at the bones! 

![Cute animal picture](https://i.ytimg.com/vi/8mtS4mOPoQ0/hqdefault.jpg)
