### PR TITLE
return bytes in 'hash' of getBlock

### DIFF
--- a/tests/core/utilities/test_abi.py
+++ b/tests/core/utilities/test_abi.py
@@ -2,9 +2,11 @@
 import pytest
 
 from web3.utils.abi import (
-    BASE_RETURN_NORMALIZERS,
     abi_data_tree,
     map_abi_data,
+)
+from web3.utils.normalizers import (
+    BASE_RETURN_NORMALIZERS,
 )
 
 

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -34,7 +34,6 @@ from web3.exceptions import (
 )
 
 from web3.utils.abi import (
-    BASE_RETURN_NORMALIZERS,
     filter_by_type,
     filter_by_name,
     filter_by_argument_count,
@@ -62,6 +61,9 @@ from web3.utils.exception import (
 from web3.utils.filters import (
     construct_event_filter_params,
     PastLogFilter,
+)
+from web3.utils.normalizers import (
+    BASE_RETURN_NORMALIZERS,
 )
 from web3.utils.validation import (
     validate_abi,

--- a/web3/utils/abi.py
+++ b/web3/utils/abi.py
@@ -29,15 +29,6 @@ from eth_abi.abi import (
 from web3.utils.formatters import (
     recursive_map,
 )
-from web3.utils.normalizers import (
-    addresses_checksummed,
-    decode_abi_strings,
-)
-
-BASE_RETURN_NORMALIZERS = [
-    addresses_checksummed,
-    decode_abi_strings,
-]
 
 
 def filter_by_type(_type, contract_abi):
@@ -405,6 +396,7 @@ def abi_to_signature(abi):
 ########################################################
 
 
+@curry
 def map_abi_data(normalizers, types, data):
     '''
     This function will apply normalizers to your data, in the

--- a/web3/utils/blocks.py
+++ b/web3/utils/blocks.py
@@ -36,6 +36,8 @@ def is_hex_encoded_block_number(value):
 def select_method_for_block_identifier(value, if_hash, if_number, if_predefined):
     if is_predefined_block_number(value):
         return if_predefined
+    elif isinstance(value, bytes):
+        return if_hash
     elif is_hex_encoded_block_hash(value):
         return if_hash
     elif is_integer(value) and (0 <= value < 2**256):

--- a/web3/utils/events.py
+++ b/web3/utils/events.py
@@ -18,12 +18,15 @@ from eth_abi.abi import (
 )
 
 from .abi import (
-    BASE_RETURN_NORMALIZERS,
     exclude_indexed_event_inputs,
     get_abi_input_names,
     get_indexed_event_inputs,
     map_abi_data,
     normalize_event_input_types,
+)
+
+from web3.utils.normalizers import (
+    BASE_RETURN_NORMALIZERS,
 )
 
 

--- a/web3/utils/module_testing/eth_module.py
+++ b/web3/utils/module_testing/eth_module.py
@@ -7,6 +7,7 @@ from eth_abi import (
 )
 
 from eth_utils import (
+    encode_hex,
     is_address,
     is_string,
     is_boolean,
@@ -281,7 +282,7 @@ class EthModuleTest(object):
         receipt = web3.eth.getTransactionReceipt(mined_txn_hash)
         assert is_dict(receipt)
         assert receipt['blockNumber'] == block_with_txn['number']
-        assert receipt['blockHash'] == block_with_txn['hash']
+        assert receipt['blockHash'] == encode_hex(block_with_txn['hash'])
         assert receipt['transactionIndex'] == 0
         assert receipt['transactionHash'] == mined_txn_hash
 
@@ -304,7 +305,7 @@ class EthModuleTest(object):
         receipt = web3.eth.getTransactionReceipt(txn_hash_with_log)
         assert is_dict(receipt)
         assert receipt['blockNumber'] == block_with_txn_with_log['number']
-        assert receipt['blockHash'] == block_with_txn_with_log['hash']
+        assert receipt['blockHash'] == encode_hex(block_with_txn_with_log['hash'])
         assert receipt['transactionIndex'] == 0
         assert receipt['transactionHash'] == txn_hash_with_log
 
@@ -312,7 +313,7 @@ class EthModuleTest(object):
         log_entry = receipt['logs'][0]
 
         assert log_entry['blockNumber'] == block_with_txn_with_log['number']
-        assert log_entry['blockHash'] == block_with_txn_with_log['hash']
+        assert log_entry['blockHash'] == encode_hex(block_with_txn_with_log['hash'])
         assert log_entry['logIndex'] == 0
         assert is_same_address(log_entry['address'], emitter_contract.address)
         assert log_entry['transactionIndex'] == 0

--- a/web3/utils/normalizers.py
+++ b/web3/utils/normalizers.py
@@ -2,8 +2,18 @@
 import codecs
 import functools
 
+from eth_abi.abi import (
+    process_type,
+)
+
 from eth_utils import (
     to_checksum_address,
+)
+
+from web3.utils.encoding import (
+    hexstr_if_str,
+    to_bytes,
+    to_hex,
 )
 
 
@@ -28,3 +38,30 @@ def addresses_checksummed(abi_type, data):
 def decode_abi_strings(abi_type, data):
     if abi_type == 'string':
         return abi_type, codecs.decode(data, 'utf8', 'backslashreplace')
+
+
+@implicitly_identity
+def abi_bytes_to_hex(abi_type, data):
+    base, sub, arrlist = process_type(abi_type)
+    if base == 'bytes' and not arrlist:
+        bytes_data = hexstr_if_str(to_bytes, data)
+        if len(bytes_data) != int(sub):
+            raise ValueError(
+                "This value was expected to be %d bytes, but instead was %d: %r" % (
+                    (sub, len(bytes_data), data)
+                )
+            )
+        return abi_type, to_hex(bytes_data)
+
+
+@implicitly_identity
+def abi_int_to_hex(abi_type, data):
+    base, _sub, arrlist = process_type(abi_type)
+    if base == 'uint' and not arrlist:
+        return abi_type, hexstr_if_str(to_hex, data)
+
+
+BASE_RETURN_NORMALIZERS = [
+    addresses_checksummed,
+    decode_abi_strings,
+]


### PR DESCRIPTION
### What was wrong?

#340 - 'hash' in getBlock was returning a hex string, let's return a bytes value instead

### How was it fixed?

A small change to `pythonic_middleware` gets this done. The other ramifications are a bit larger.

In many tests, the returned hash gets passed back in as an argument to other json-rpc calls. They were all expecting a hex string value. So this commit also allows bytes as input when retrieving block by hash.

It accomplishes this with an "abi-like" mechanism in `pythonic_middleware` to handle bytes values passed in where a block hash goes (treating it as bytes32).

Finally, had to move `BASE_RETURN_NORMALIZERS` to web3/utils/normalizers.py to avoid an import cycle. (makes more sense there anyway)

#### Cute Animal Picture

![Cute animal picture](https://i.pinimg.com/736x/50/cc/92/50cc92c00f84e9e588f981f469f8a684--cute-unicorn-drawing-unicorn-drawings.jpg)

^ This should totally be our Devcon mascot