### PR TITLE
Return bytes for transaction and block hashes

### DIFF
--- a/tests/core/contracts/test_extracting_event_data.py
+++ b/tests/core/contracts/test_extracting_event_data.py
@@ -2,7 +2,6 @@ import pytest
 
 from eth_utils import (
     decode_hex,
-    force_text,
     is_same_address,
 )
 
@@ -129,7 +128,7 @@ def test_dynamic_length_argument_extraction(web3,
     event_data = get_event_data(event_abi, log_entry)
 
     expected_args = {
-        "arg0": force_text(decode_hex(string_0_topic)),
+        "arg0": decode_hex(string_0_topic),
         "arg1": string_1,
     }
 

--- a/tests/core/filtering/test_contract_on_event_filtering.py
+++ b/tests/core/filtering/test_contract_on_event_filtering.py
@@ -34,7 +34,7 @@ def test_on_filter_using_get_interface(web3,
     log_entries = filter.get()
 
     assert len(log_entries) == 1
-    assert log_entries[0]['transactionHash'] == txn_hash.encode()
+    assert log_entries[0]['transactionHash'] == txn_hash
 
 
 @flaky(max_runs=3)
@@ -64,7 +64,7 @@ def test_on_filter_with_only_event_name(web3,
     filter.stop_watching(30)
 
     assert len(seen_logs) == 1
-    assert seen_logs[0]['transactionHash'] == txn_hash.encode()
+    assert seen_logs[0]['transactionHash'] == txn_hash
 
 
 @flaky(max_runs=3)
@@ -108,7 +108,7 @@ def test_on_filter_with_event_name_and_single_argument(web3,
     filter.stop_watching(30)
 
     assert len(seen_logs) == 2
-    assert {l['transactionHash'].decode() for l in seen_logs} == set(txn_hashes[1:])
+    assert {l['transactionHash'] for l in seen_logs} == set(txn_hashes[1:])
 
 
 @flaky(max_runs=3)
@@ -152,4 +152,4 @@ def test_on_filter_with_event_name_and_non_indexed_argument(web3,
     filter.stop_watching(30)
 
     assert len(seen_logs) == 1
-    assert seen_logs[0]['transactionHash'] == txn_hashes[1].encode()
+    assert seen_logs[0]['transactionHash'] == txn_hashes[1]

--- a/tests/core/filtering/test_contract_on_event_filtering.py
+++ b/tests/core/filtering/test_contract_on_event_filtering.py
@@ -34,7 +34,7 @@ def test_on_filter_using_get_interface(web3,
     log_entries = filter.get()
 
     assert len(log_entries) == 1
-    assert log_entries[0]['transactionHash'] == txn_hash
+    assert log_entries[0]['transactionHash'] == txn_hash.encode()
 
 
 @flaky(max_runs=3)
@@ -64,7 +64,7 @@ def test_on_filter_with_only_event_name(web3,
     filter.stop_watching(30)
 
     assert len(seen_logs) == 1
-    assert seen_logs[0]['transactionHash'] == txn_hash
+    assert seen_logs[0]['transactionHash'] == txn_hash.encode()
 
 
 @flaky(max_runs=3)
@@ -108,7 +108,7 @@ def test_on_filter_with_event_name_and_single_argument(web3,
     filter.stop_watching(30)
 
     assert len(seen_logs) == 2
-    assert {l['transactionHash'] for l in seen_logs} == set(txn_hashes[1:])
+    assert {l['transactionHash'].decode() for l in seen_logs} == set(txn_hashes[1:])
 
 
 @flaky(max_runs=3)
@@ -152,4 +152,4 @@ def test_on_filter_with_event_name_and_non_indexed_argument(web3,
     filter.stop_watching(30)
 
     assert len(seen_logs) == 1
-    assert seen_logs[0]['transactionHash'] == txn_hashes[1]
+    assert seen_logs[0]['transactionHash'] == txn_hashes[1].encode()

--- a/web3/middleware/pythonic.py
+++ b/web3/middleware/pythonic.py
@@ -119,6 +119,7 @@ def to_hexbytes(num_bytes, val):
 
 
 TRANSACTION_FORMATTERS = {
+    'blockHash': apply_formatter_if(to_hexbytes(32), is_not_null),
     'blockNumber': apply_formatter_if(to_integer_if_hex, is_not_null),
     'transactionIndex': apply_formatter_if(to_integer_if_hex, is_not_null),
     'nonce': to_integer_if_hex,
@@ -135,7 +136,7 @@ transaction_formatter = apply_formatters_to_dict(TRANSACTION_FORMATTERS)
 
 
 LOG_ENTRY_FORMATTERS = {
-    'blockHash': apply_formatter_if(to_ascii_if_bytes, is_not_null),
+    'blockHash': apply_formatter_if(to_hexbytes(32), is_not_null),
     'blockNumber': apply_formatter_if(to_integer_if_hex, is_not_null),
     'transactionIndex': apply_formatter_if(to_integer_if_hex, is_not_null),
     'logIndex': to_integer_if_hex,
@@ -149,7 +150,7 @@ log_entry_formatter = apply_formatters_to_dict(LOG_ENTRY_FORMATTERS)
 
 
 RECEIPT_FORMATTERS = {
-    'blockHash': apply_formatter_if(to_ascii_if_bytes, is_not_null),
+    'blockHash': apply_formatter_if(to_hexbytes(32), is_not_null),
     'blockNumber': apply_formatter_if(to_integer_if_hex, is_not_null),
     'transactionIndex': apply_formatter_if(to_integer_if_hex, is_not_null),
     'transactionHash': to_ascii_if_bytes,
@@ -169,6 +170,9 @@ BLOCK_FORMATTERS = {
     'timestamp': to_integer_if_hex,
     'hash': apply_formatter_if(to_hexbytes(32), is_not_null),
     'number': apply_formatter_if(to_integer_if_hex, is_not_null),
+    'parentHash': apply_formatter_if(to_hexbytes(32), is_not_null),
+    'sha3Uncles': apply_formatter_if(to_hexbytes(32), is_not_null),
+    'uncles': apply_formatter_to_array(to_hexbytes(32)),
     'difficulty': to_integer_if_hex,
     'totalDifficulty': to_integer_if_hex,
     'transactions': apply_one_of_formatters((

--- a/web3/middleware/pythonic.py
+++ b/web3/middleware/pythonic.py
@@ -128,7 +128,7 @@ TRANSACTION_FORMATTERS = {
     'value': to_integer_if_hex,
     'from': to_checksum_address,
     'to': apply_formatter_if(to_checksum_address, is_address),
-    'hash': to_ascii_if_bytes,
+    'hash': to_hexbytes(32),
 }
 
 
@@ -139,6 +139,7 @@ LOG_ENTRY_FORMATTERS = {
     'blockHash': apply_formatter_if(to_hexbytes(32), is_not_null),
     'blockNumber': apply_formatter_if(to_integer_if_hex, is_not_null),
     'transactionIndex': apply_formatter_if(to_integer_if_hex, is_not_null),
+    'transactionHash': apply_formatter_if(to_hexbytes(32), is_not_null),
     'logIndex': to_integer_if_hex,
     'address': to_checksum_address,
     'topics': apply_formatter_to_array(to_ascii_if_bytes),
@@ -153,7 +154,7 @@ RECEIPT_FORMATTERS = {
     'blockHash': apply_formatter_if(to_hexbytes(32), is_not_null),
     'blockNumber': apply_formatter_if(to_integer_if_hex, is_not_null),
     'transactionIndex': apply_formatter_if(to_integer_if_hex, is_not_null),
-    'transactionHash': to_ascii_if_bytes,
+    'transactionHash': to_hexbytes(32),
     'cumulativeGasUsed': to_integer_if_hex,
     'gasUsed': to_integer_if_hex,
     'contractAddress': apply_formatter_if(to_checksum_address, is_not_null),
@@ -177,7 +178,7 @@ BLOCK_FORMATTERS = {
     'totalDifficulty': to_integer_if_hex,
     'transactions': apply_one_of_formatters((
         (apply_formatter_to_array(transaction_formatter), is_array_of_dicts),
-        (apply_formatter_to_array(to_ascii_if_bytes), is_array_of_strings),
+        (apply_formatter_to_array(to_hexbytes(32)), is_array_of_strings),
     )),
 }
 
@@ -280,7 +281,9 @@ pythonic_middleware = construct_formatting_middleware(
             apply_formatter_at_index(integer_to_hex, 1),
         ),
         'eth_getTransactionByBlockHashAndIndex': format_abi_parameters(['bytes32', 'uint']),
+        'eth_getTransactionByHash': format_abi_parameters(['bytes32']),
         'eth_getTransactionCount': apply_formatter_at_index(block_number_formatter, 1),
+        'eth_getTransactionReceipt': format_abi_parameters(['bytes32']),
         'eth_getUncleCountByBlockHash': format_abi_parameters(['bytes32']),
         'eth_getUncleCountByBlockNumber': apply_formatter_at_index(block_number_formatter, 0),
         'eth_newFilter': apply_formatter_at_index(filter_params_formatter, 0),
@@ -332,8 +335,8 @@ pythonic_middleware = construct_formatting_middleware(
             apply_formatter_if(str, is_integer),
             to_integer_if_hex,
         ),
-        'eth_sendRawTransaction': to_ascii_if_bytes,
-        'eth_sendTransaction': to_ascii_if_bytes,
+        'eth_sendRawTransaction': to_hexbytes(32),
+        'eth_sendTransaction': to_hexbytes(32),
         'eth_syncing': apply_formatter_if(syncing_formatter, is_not_false),
         # SHH
         'shh_version': to_integer_if_hex,

--- a/web3/utils/events.py
+++ b/web3/utils/events.py
@@ -140,7 +140,6 @@ def get_event_abi_types_for_decoding(event_inputs):
             yield input_abi['type']
 
 
-@coerce_return_to_text
 def get_event_data(event_abi, log_entry):
     """
     Given an event ABI and a log entry for that event, return the decoded

--- a/web3/utils/module_testing/eth_module.py
+++ b/web3/utils/module_testing/eth_module.py
@@ -17,6 +17,9 @@ from eth_utils import (
     remove_0x_prefix,
 )
 
+from web3.utils.datastructures import (
+    HexBytes,
+)
 
 UNKOWN_HASH = '0xdeadbeef00000000000000000000000000000000000000000000000000000000'
 
@@ -182,7 +185,8 @@ class EthModuleTest(object):
         txn_hash = web3.eth.sendRawTransaction(
             '0xf8648085174876e8008252089439eeed73fb1d3855e90cbd42f348b3d7b340aaa601801ba0ec1295f00936acd0c2cb90ab2cdaacb8bf5e11b3d9957833595aca9ceedb7aada05dfc8937baec0e26029057abd3a1ef8c505dca2cdc07ffacb046d090d2bea06a'  # noqa: E501
         )
-        assert txn_hash == '0x1f80f8ab5f12a45be218f76404bda64d37270a6f4f86ededd0eb599f80548c13'
+        expected = HexBytes('0x1f80f8ab5f12a45be218f76404bda64d37270a6f4f86ededd0eb599f80548c13')
+        assert txn_hash == expected
 
     def test_eth_call(self, web3, math_contract):
         coinbase = web3.eth.coinbase
@@ -258,7 +262,7 @@ class EthModuleTest(object):
     def test_eth_getTransactionByHash(self, web3, mined_txn_hash):
         transaction = web3.eth.getTransaction(mined_txn_hash)
         assert is_dict(transaction)
-        assert transaction['hash'] == mined_txn_hash
+        assert transaction['hash'] == HexBytes(mined_txn_hash)
 
     def test_eth_getTransactionByHash_contract_creation(self,
                                                         web3,
@@ -270,12 +274,12 @@ class EthModuleTest(object):
     def test_eth_getTransactionByBlockHashAndIndex(self, web3, block_with_txn, mined_txn_hash):
         transaction = web3.eth.getTransactionFromBlock(block_with_txn['hash'], 0)
         assert is_dict(transaction)
-        assert transaction['hash'] == mined_txn_hash
+        assert transaction['hash'] == HexBytes(mined_txn_hash)
 
     def test_eth_getTransactionByBlockNumberAndIndex(self, web3, block_with_txn, mined_txn_hash):
         transaction = web3.eth.getTransactionFromBlock(block_with_txn['number'], 0)
         assert is_dict(transaction)
-        assert transaction['hash'] == mined_txn_hash
+        assert transaction['hash'] == HexBytes(mined_txn_hash)
 
     def test_eth_getTransactionReceipt_mined(self, web3, block_with_txn, mined_txn_hash):
         receipt = web3.eth.getTransactionReceipt(mined_txn_hash)
@@ -283,7 +287,7 @@ class EthModuleTest(object):
         assert receipt['blockNumber'] == block_with_txn['number']
         assert receipt['blockHash'] == block_with_txn['hash']
         assert receipt['transactionIndex'] == 0
-        assert receipt['transactionHash'] == mined_txn_hash
+        assert receipt['transactionHash'] == HexBytes(mined_txn_hash)
 
     def test_eth_getTransactionReceipt_unmined(self, web3, unlocked_account):
         txn_hash = web3.eth.sendTransaction({
@@ -306,7 +310,7 @@ class EthModuleTest(object):
         assert receipt['blockNumber'] == block_with_txn_with_log['number']
         assert receipt['blockHash'] == block_with_txn_with_log['hash']
         assert receipt['transactionIndex'] == 0
-        assert receipt['transactionHash'] == txn_hash_with_log
+        assert receipt['transactionHash'] == HexBytes(txn_hash_with_log)
 
         assert len(receipt['logs']) == 1
         log_entry = receipt['logs'][0]
@@ -316,7 +320,7 @@ class EthModuleTest(object):
         assert log_entry['logIndex'] == 0
         assert is_same_address(log_entry['address'], emitter_contract.address)
         assert log_entry['transactionIndex'] == 0
-        assert log_entry['transactionHash'] == txn_hash_with_log
+        assert log_entry['transactionHash'] == HexBytes(txn_hash_with_log)
 
     def test_eth_getUncleByBlockHashAndIndex(self, web3):
         # TODO: how do we make uncles....

--- a/web3/utils/module_testing/eth_module.py
+++ b/web3/utils/module_testing/eth_module.py
@@ -7,7 +7,6 @@ from eth_abi import (
 )
 
 from eth_utils import (
-    encode_hex,
     is_address,
     is_string,
     is_boolean,
@@ -282,7 +281,7 @@ class EthModuleTest(object):
         receipt = web3.eth.getTransactionReceipt(mined_txn_hash)
         assert is_dict(receipt)
         assert receipt['blockNumber'] == block_with_txn['number']
-        assert receipt['blockHash'] == encode_hex(block_with_txn['hash'])
+        assert receipt['blockHash'] == block_with_txn['hash']
         assert receipt['transactionIndex'] == 0
         assert receipt['transactionHash'] == mined_txn_hash
 
@@ -305,7 +304,7 @@ class EthModuleTest(object):
         receipt = web3.eth.getTransactionReceipt(txn_hash_with_log)
         assert is_dict(receipt)
         assert receipt['blockNumber'] == block_with_txn_with_log['number']
-        assert receipt['blockHash'] == encode_hex(block_with_txn_with_log['hash'])
+        assert receipt['blockHash'] == block_with_txn_with_log['hash']
         assert receipt['transactionIndex'] == 0
         assert receipt['transactionHash'] == txn_hash_with_log
 
@@ -313,7 +312,7 @@ class EthModuleTest(object):
         log_entry = receipt['logs'][0]
 
         assert log_entry['blockNumber'] == block_with_txn_with_log['number']
-        assert log_entry['blockHash'] == encode_hex(block_with_txn_with_log['hash'])
+        assert log_entry['blockHash'] == block_with_txn_with_log['hash']
         assert log_entry['logIndex'] == 0
         assert is_same_address(log_entry['address'], emitter_contract.address)
         assert log_entry['transactionIndex'] == 0


### PR DESCRIPTION
### What was wrong?

#340 transaction and block hashes were returned as hex strings

### How was it fixed?

they are now returned as bytes

#### Cute Animal Picture

![Cute animal picture](https://pbs.twimg.com/profile_images/552821566141394944/ibzqjwEN.jpeg)
