### PR TITLE
return bytes from sha3 and soliditySha3

### DIFF
--- a/tests/core/contracts/test_extracting_event_data.py
+++ b/tests/core/contracts/test_extracting_event_data.py
@@ -1,7 +1,7 @@
 import pytest
 
 from eth_utils import (
-    decode_hex,
+    encode_hex,
     is_same_address,
 )
 
@@ -123,12 +123,12 @@ def test_dynamic_length_argument_extraction(web3,
     assert event_topic in log_entry['topics']
 
     string_0_topic = web3.sha3(text=string_0)
-    assert string_0_topic in log_entry['topics']
+    assert encode_hex(string_0_topic) in log_entry['topics']
 
     event_data = get_event_data(event_abi, log_entry)
 
     expected_args = {
-        "arg0": decode_hex(string_0_topic),
+        "arg0": string_0_topic,
         "arg1": string_1,
     }
 

--- a/tests/core/web3-module/test_sha3.py
+++ b/tests/core/web3-module/test_sha3.py
@@ -3,13 +3,14 @@
 import pytest
 
 from web3 import Web3
+from web3.utils.datastructures import HexBytes
 
 
 @pytest.mark.parametrize(
     'message, digest',
     [
-        ('cowmö', '0x0f355f04c0a06eebac1d219b34c598f85a1169badee164be8a30345944885fe8'),
-        ('', '0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470'),
+        ('cowmö', HexBytes('0x0f355f04c0a06eebac1d219b34c598f85a1169badee164be8a30345944885fe8')),
+        ('', HexBytes('0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470')),
     ]
 )
 def test_sha3_text(message, digest):
@@ -19,8 +20,22 @@ def test_sha3_text(message, digest):
 @pytest.mark.parametrize(
     'hexstr, digest',
     [
-        ('0x636f776dc3b6', '0x0f355f04c0a06eebac1d219b34c598f85a1169badee164be8a30345944885fe8'),
-        ('0x', '0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470'),
+        (
+            '0x636f776dc3b6',
+            HexBytes('0x0f355f04c0a06eebac1d219b34c598f85a1169badee164be8a30345944885fe8')
+        ),
+        (
+            '636f776dc3b6',
+            HexBytes('0x0f355f04c0a06eebac1d219b34c598f85a1169badee164be8a30345944885fe8')
+        ),
+        (
+            '0x',
+            HexBytes('0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470')
+        ),
+        (
+            '',
+            HexBytes('0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470')
+        ),
     ]
 )
 def test_sha3_hexstr(hexstr, digest):
@@ -43,8 +58,14 @@ def test_sha3_primitive_invalid(primitive, exception):
 @pytest.mark.parametrize(
     'primitive, digest',
     [
-        (b'cowm\xc3\xb6', '0x0f355f04c0a06eebac1d219b34c598f85a1169badee164be8a30345944885fe8'),
-        (b'', '0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470'),
+        (
+            b'cowm\xc3\xb6',
+            HexBytes('0x0f355f04c0a06eebac1d219b34c598f85a1169badee164be8a30345944885fe8')
+        ),
+        (
+            b'',
+            HexBytes('0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470')
+        ),
     ]
 )
 def test_sha3_primitive(primitive, digest):

--- a/web3/main.py
+++ b/web3/main.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 from eth_utils import (
     apply_to_return_value,
     add_0x_prefix,
-    encode_hex,
     from_wei,
     is_address,
     is_checksum_address,
@@ -39,6 +38,9 @@ from web3.manager import (
     RequestManager,
 )
 
+from web3.utils.datastructures import (
+    HexBytes,
+)
 from web3.utils.encoding import (
     hex_encode_abi_type,
     to_bytes,
@@ -111,7 +113,7 @@ class Web3(object):
         self.manager.setProvider(providers)
 
     @staticmethod
-    @apply_to_return_value(encode_hex)
+    @apply_to_return_value(HexBytes)
     def sha3(primitive=None, text=None, hexstr=None):
         if isinstance(primitive, (bytes, int, type(None))):
             input_bytes = to_bytes(primitive, hexstr=hexstr, text=text)

--- a/web3/utils/module_testing/web3_module.py
+++ b/web3/utils/module_testing/web3_module.py
@@ -1,5 +1,7 @@
 import pytest
 
+from web3.utils.datastructures import HexBytes
+
 
 class Web3ModuleTest(object):
     def test_web3_clientVersion(self, web3):
@@ -17,52 +19,52 @@ class Web3ModuleTest(object):
             (
                 ['bool'],
                 [True],
-                "0x5fe7f977e71dba2ea1a68e21057beebb9be2ac30c6410aa38d4f3fbe41dcffd2",
+                HexBytes("0x5fe7f977e71dba2ea1a68e21057beebb9be2ac30c6410aa38d4f3fbe41dcffd2"),
             ),
             (
                 ['uint8', 'uint8', 'uint8'],
                 [97, 98, 99],
-                "0x4e03657aea45a94fc7d47ba826c8d667c0d1e6e33a64a036ec44f58fa12d6c45",
+                HexBytes("0x4e03657aea45a94fc7d47ba826c8d667c0d1e6e33a64a036ec44f58fa12d6c45"),
             ),
             (
                 ['uint248'],
                 [30],
-                "0x30f95d210785601eb33ae4d53d405b26f920e765dff87cca8e9a4aec99f82671",
+                HexBytes("0x30f95d210785601eb33ae4d53d405b26f920e765dff87cca8e9a4aec99f82671"),
             ),
             (
                 ['bool', 'uint16'],
                 [True, 299],
-                "0xed18599ccd80ee9fae9a28b0e34a5573c3233d7468f808fd659bc171cf0b43bd",
+                HexBytes("0xed18599ccd80ee9fae9a28b0e34a5573c3233d7468f808fd659bc171cf0b43bd"),
             ),
             (
                 ['int256'],
                 [-10],
-                "0xd6fb717f7e270a360f5093ce6a7a3752183e89c9a9afe5c0cb54b458a304d3d5",
+                HexBytes("0xd6fb717f7e270a360f5093ce6a7a3752183e89c9a9afe5c0cb54b458a304d3d5"),
             ),
             (
                 ['int256'],
                 [10],
-                "0xc65a7bb8d6351c1cf70c95a316cc6a92839c986682d98bc35f958f4883f9d2a8",
+                HexBytes("0xc65a7bb8d6351c1cf70c95a316cc6a92839c986682d98bc35f958f4883f9d2a8"),
             ),
             (
                 ['int8', 'uint8'],
                 [-10, 18],
-                "0x5c6ab1e634c08d9c0f4df4d789e8727943ef010dd7ca8e3c89de197a26d148be",
+                HexBytes("0x5c6ab1e634c08d9c0f4df4d789e8727943ef010dd7ca8e3c89de197a26d148be"),
             ),
             (
                 ['address'],
                 ["0x49eddd3769c0712032808d86597b84ac5c2f5614"],
-                "0x2ff37b5607484cd4eecf6d13292e22bd6e5401eaffcc07e279583bc742c68882",
+                HexBytes("0x2ff37b5607484cd4eecf6d13292e22bd6e5401eaffcc07e279583bc742c68882"),
             ),
             (
                 ['bytes2'],
                 ['0x5402'],
-                "0x4ed9171bda52fca71ab28e7f452bd6eacc3e5a568a47e0fa53b503159a9b8910",
+                HexBytes("0x4ed9171bda52fca71ab28e7f452bd6eacc3e5a568a47e0fa53b503159a9b8910"),
             ),
             (
                 ['bytes3'],
                 ['0x5402'],
-                "0x4ed9171bda52fca71ab28e7f452bd6eacc3e5a568a47e0fa53b503159a9b8910",
+                HexBytes("0x4ed9171bda52fca71ab28e7f452bd6eacc3e5a568a47e0fa53b503159a9b8910"),
             ),
             (
                 ['bytes'],
@@ -70,13 +72,13 @@ class Web3ModuleTest(object):
                     '0x636865636b6c6f6e6762797465737472696e676167'
                     '61696e7374736f6c6964697479736861336861736866756e6374696f6e'
                 ],
-                "0xd78a84d65721b67e4011b10c99dafdedcdcd7cb30153064f773e210b4762e22f",
+                HexBytes("0xd78a84d65721b67e4011b10c99dafdedcdcd7cb30153064f773e210b4762e22f"),
             ),
 
             (
                 ['string'],
                 ['testing a string!'],
-                "0xe8c275c0b4070a5ec6cfcb83f0ba394b30ddd283de785d43f2eabfb04bd96747",
+                HexBytes("0xe8c275c0b4070a5ec6cfcb83f0ba394b30ddd283de785d43f2eabfb04bd96747"),
             ),
             (
                 ['string', 'bool', 'uint16', 'bytes2', 'address'],
@@ -87,37 +89,37 @@ class Web3ModuleTest(object):
                     '0x5402',
                     "0x49eddd3769c0712032808d86597b84ac5c2f5614",
                 ],
-                "0x8cc6eabb25b842715e8ca39e2524ed946759aa37bfb7d4b81829cf5a7e266103",
+                HexBytes("0x8cc6eabb25b842715e8ca39e2524ed946759aa37bfb7d4b81829cf5a7e266103"),
             ),
             (
                 ['bool[2][]'],
                 [[[True, False], [False, True]]],
-                "0x1eef261f2eb51a8c736d52be3f91ff79e78a9ec5df2b7f50d0c6f98ed1e2bc06",
+                HexBytes("0x1eef261f2eb51a8c736d52be3f91ff79e78a9ec5df2b7f50d0c6f98ed1e2bc06"),
             ),
             (
                 ['bool[]'],
                 [[True, False, True]],
-                "0x5c6090c0461491a2941743bda5c3658bf1ea53bbd3edcde54e16205e18b45792",
+                HexBytes("0x5c6090c0461491a2941743bda5c3658bf1ea53bbd3edcde54e16205e18b45792"),
             ),
             (
                 ['uint24[]'],
                 [[1, 0, 1]],
-                "0x5c6090c0461491a2941743bda5c3658bf1ea53bbd3edcde54e16205e18b45792",
+                HexBytes("0x5c6090c0461491a2941743bda5c3658bf1ea53bbd3edcde54e16205e18b45792"),
             ),
             (
                 ['uint8[2]'],
                 [[8, 9]],
-                "0xc7694af312c4f286114180fd0ba6a52461fcee8a381636770b19a343af92538a",
+                HexBytes("0xc7694af312c4f286114180fd0ba6a52461fcee8a381636770b19a343af92538a"),
             ),
             (
                 ['uint256[2]'],
                 [[8, 9]],
-                "0xc7694af312c4f286114180fd0ba6a52461fcee8a381636770b19a343af92538a",
+                HexBytes("0xc7694af312c4f286114180fd0ba6a52461fcee8a381636770b19a343af92538a"),
             ),
             (
                 ['uint8[]'],
                 [[8]],
-                "0xf3f7a9fe364faab93b216da50a3214154f22a0a2b415b23a84c8169e8b636ee3",
+                HexBytes("0xf3f7a9fe364faab93b216da50a3214154f22a0a2b415b23a84c8169e8b636ee3"),
             ),
             (
                 ['address[]'],
@@ -125,7 +127,7 @@ class Web3ModuleTest(object):
                     "0x49EdDD3769c0712032808D86597B84ac5c2F5614",
                     "0xA6b759bBbf4B59D24acf7E06e79f3a5D104fdCE5",
                 ]],
-                "0xb98565c0c26a962fd54d93b0ed6fb9296e03e9da29d2281ed3e3473109ef7dde",
+                HexBytes("0xb98565c0c26a962fd54d93b0ed6fb9296e03e9da29d2281ed3e3473109ef7dde"),
             ),
         ),
     )


### PR DESCRIPTION
### What was wrong?

#340 sha3 was returning hex-encoded str

### How was it fixed?

sha3 and soliditySha3 returns bytes (as `HexBytes`)

#### Cute Animal Picture

![Cute animal picture](https://i.pinimg.com/736x/b1/04/54/b104542127155157bc8a42d6d2b916b7--llama-alpaca-alpaca-funny.jpg)
