### PR TITLE
Return bytes from blocks and transactions

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-eth-testrpc>=1.3.2
+eth-testrpc>=1.3.3
 ethereum>=1.6.1,<2.0
 flaky>=3.3.0
 flake8==3.4.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-eth-testrpc>=1.2.0
+eth-testrpc>=1.3.1
 ethereum>=1.6.1,<2.0
 flaky>=3.3.0
 flake8==3.4.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-eth-testrpc>=1.3.1
+eth-testrpc>=1.3.2
 ethereum>=1.6.1,<2.0
 flaky>=3.3.0
 flake8==3.4.1

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     install_requires=install_requires,
     setup_requires=['setuptools-markdown'],
     extras_require={
-        'tester': ["eth-testrpc>=1.3.2"],
+        'tester': ["eth-testrpc>=1.3.3"],
         'gevent': [
             "gevent>=1.1.1,<1.2.0",
             "geventhttpclient>=1.3.1",

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     install_requires=install_requires,
     setup_requires=['setuptools-markdown'],
     extras_require={
-        'tester': ["eth-testrpc>=1.2.0"],
+        'tester': ["eth-testrpc>=1.3.1"],
         'gevent': [
             "gevent>=1.1.1,<1.2.0",
             "geventhttpclient>=1.3.1",

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     install_requires=install_requires,
     setup_requires=['setuptools-markdown'],
     extras_require={
-        'tester': ["eth-testrpc>=1.3.1"],
+        'tester': ["eth-testrpc>=1.3.2"],
         'gevent': [
             "gevent>=1.1.1,<1.2.0",
             "geventhttpclient>=1.3.1",

--- a/web3/middleware/pythonic.py
+++ b/web3/middleware/pythonic.py
@@ -131,8 +131,14 @@ TRANSACTION_FORMATTERS = {
     'gasPrice': to_integer_if_hex,
     'value': to_integer_if_hex,
     'from': to_checksum_address,
+    'publicKey': to_hexbytes(64),
+    'r': to_hexbytes(32),
+    'raw': HexBytes,
+    's': to_hexbytes(32),
     'to': apply_formatter_if(to_checksum_address, is_address),
     'hash': to_hexbytes(32),
+    'v': apply_formatter_if(to_integer_if_hex, is_not_null),
+    'standardV': apply_formatter_if(to_integer_if_hex, is_not_null),
 }
 
 

--- a/web3/providers/tester.py
+++ b/web3/providers/tester.py
@@ -4,9 +4,10 @@ from cytoolz.functoolz import (
 )
 
 from eth_utils import (
+    decode_hex,
+    force_obj_to_text,
     is_integer,
     is_string,
-    decode_hex,
 )
 
 from web3.middleware import (
@@ -50,6 +51,12 @@ TRANSACTION_FORMATTERS = {
 }
 
 
+def ethtestrpc_string_middleware(make_request, web3):
+    def middleware(method, params):
+        return force_obj_to_text(make_request(method, params))
+    return middleware
+
+
 ethtestrpc_middleware = construct_formatting_middleware(
     request_formatters={
         'eth_uninstallFilter': apply_formatter_at_index(to_integer_if_hex, 0),
@@ -90,6 +97,7 @@ def ethereum_tester_personal_remapper_middleware(make_request, web3):
 class EthereumTesterProvider(BaseProvider):
     middlewares = [
         ethtestrpc_middleware,
+        ethtestrpc_string_middleware,
         ethtestrpc_exception_middleware,
         ethereum_tester_personal_remapper_middleware,
     ]


### PR DESCRIPTION
### What was wrong?

Transactions and blocks returned hex strings in their fields. see #340

### How was it fixed?

Return bytes (HexBytes) instead.

These tests will fail until a version higher than 1.3.1 of eth-testrpc is released, because it depends on a couple fixes where logsBloom will return a full 256 bytes as a hex-encoded string:
 * https://github.com/pipermerriam/eth-testrpc/pull/100 (merged and deployed)
 * https://github.com/pipermerriam/eth-testrpc/pull/101 (waiting for review)

It also appears that `nonce` is returned with 32 bytes, but the yellow paper defines it as only having 8 bytes. For now, web3 just trims the left 0 bytes down to size, but that could be removed if this is merged:

https://github.com/pipermerriam/eth-testrpc/pull/102 (not critical)

#### Cute Animal Picture

![Cute animal picture](https://i.pinimg.com/564x/3e/82/c6/3e82c664384658bb4954de0dd601990a--llama-llama-llama-shirt.jpg)