### PR TITLE
Return bytes from eth.getCode

### DIFF
--- a/tests/core/contracts/test_concise_contract.py
+++ b/tests/core/contracts/test_concise_contract.py
@@ -3,6 +3,10 @@ import sys
 
 import pytest
 
+from eth_utils import (
+    decode_hex,
+)
+
 from web3.contract import (
     CONCISE_NORMALIZERS,
     ConciseContract,
@@ -86,8 +90,8 @@ def test_class_construction_sets_class_vars(web3,
     math = MathContract(some_address)
     classic = math._classic_contract
     assert classic.web3 == web3
-    assert classic.bytecode == MATH_CODE
-    assert classic.bytecode_runtime == MATH_RUNTIME
+    assert classic.bytecode == decode_hex(MATH_CODE)
+    assert classic.bytecode_runtime == decode_hex(MATH_RUNTIME)
 
 
 def test_conciscecontract_keeps_custom_normalizers_on_base(web3):

--- a/tests/core/contracts/test_contract_class_construction.py
+++ b/tests/core/contracts/test_contract_class_construction.py
@@ -1,6 +1,10 @@
 import json
 import pytest
 
+from eth_utils import (
+    decode_hex,
+)
+
 from web3.contract import Contract
 
 
@@ -15,8 +19,8 @@ def test_class_construction_sets_class_vars(web3,
     )
 
     assert MathContract.web3 == web3
-    assert MathContract.bytecode == MATH_CODE
-    assert MathContract.bytecode_runtime == MATH_RUNTIME
+    assert MathContract.bytecode == decode_hex(MATH_CODE)
+    assert MathContract.bytecode_runtime == decode_hex(MATH_RUNTIME)
 
 
 def test_error_to_instantiate_base_class():

--- a/tests/core/contracts/test_contract_deployment.py
+++ b/tests/core/contracts/test_contract_deployment.py
@@ -2,7 +2,7 @@
 import pytest
 
 from eth_utils import (
-    force_bytes,
+    decode_hex,
 )
 
 # Ignore warning in pyethereum 1.6 - will go away with the upgrade
@@ -20,7 +20,7 @@ def test_contract_deployment_no_constructor(web3, MathContract,
     contract_address = txn_receipt['contractAddress']
 
     blockchain_code = web3.eth.getCode(contract_address)
-    assert force_bytes(blockchain_code) == force_bytes(MATH_RUNTIME)
+    assert blockchain_code == decode_hex(MATH_RUNTIME)
 
 
 def test_contract_deployment_with_constructor_without_args(web3,
@@ -35,7 +35,7 @@ def test_contract_deployment_with_constructor_without_args(web3,
     contract_address = txn_receipt['contractAddress']
 
     blockchain_code = web3.eth.getCode(contract_address)
-    assert force_bytes(blockchain_code) == force_bytes(SIMPLE_CONSTRUCTOR_RUNTIME)
+    assert blockchain_code == decode_hex(SIMPLE_CONSTRUCTOR_RUNTIME)
 
 
 def test_contract_deployment_with_constructor_with_arguments(web3,
@@ -50,7 +50,7 @@ def test_contract_deployment_with_constructor_with_arguments(web3,
     contract_address = txn_receipt['contractAddress']
 
     blockchain_code = web3.eth.getCode(contract_address)
-    assert force_bytes(blockchain_code) == force_bytes(WITH_CONSTRUCTOR_ARGUMENTS_RUNTIME)
+    assert blockchain_code == decode_hex(WITH_CONSTRUCTOR_ARGUMENTS_RUNTIME)
 
 
 def test_contract_deployment_with_constructor_with_address_argument(web3,
@@ -67,4 +67,4 @@ def test_contract_deployment_with_constructor_with_address_argument(web3,
     contract_address = txn_receipt['contractAddress']
 
     blockchain_code = web3.eth.getCode(contract_address)
-    assert force_bytes(blockchain_code) == force_bytes(WITH_CONSTRUCTOR_ADDRESS_RUNTIME)
+    assert blockchain_code == decode_hex(WITH_CONSTRUCTOR_ADDRESS_RUNTIME)

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -9,8 +9,6 @@ from eth_utils import (
     function_abi_to_4byte_selector,
     encode_hex,
     add_0x_prefix,
-    remove_0x_prefix,
-    force_bytes,
     coerce_return_to_text,
     force_obj_to_bytes,
     to_normalized_address,
@@ -46,11 +44,17 @@ from web3.utils.abi import (
     merge_args_and_kwargs,
     check_if_arguments_can_be_encoded,
 )
+from web3.utils.datastructures import (
+    HexBytes,
+)
 from web3.utils.decorators import (
     combomethod,
 )
 from web3.utils.empty import (
     empty,
+)
+from web3.utils.encoding import (
+    to_hex,
 )
 from web3.utils.events import (
     get_event_data,
@@ -78,7 +82,7 @@ DEPRECATED_SIGNATURE_MESSAGE = (
     "'Contract.factory(...)' class methog."
 )
 
-ACCEPTABLE_EMPTY_STRINGS = ["0x", b"0x", ""]
+ACCEPTABLE_EMPTY_STRINGS = ["0x", b"0x", "", b""]
 
 
 class Contract(object):
@@ -149,6 +153,11 @@ class Contract(object):
         elif key == 'address':
             validate_address(val)
             return to_normalized_address(val)
+        elif key in {
+            'bytecode_runtime',
+            'bytecode',
+        }:
+            return HexBytes(val)
         else:
             return val
 
@@ -633,10 +642,7 @@ class Contract(object):
             )
 
         if data:
-            return add_0x_prefix(
-                force_bytes(remove_0x_prefix(data)) +
-                force_bytes(remove_0x_prefix(encode_hex(encoded_arguments)))
-            )
+            return to_hex(HexBytes(data) + encoded_arguments)
         else:
             return encode_hex(encoded_arguments)
 
@@ -665,7 +671,7 @@ class Contract(object):
                 cls._encode_abi(constructor_abi, arguments, data=cls.bytecode)
             )
         else:
-            deploy_data = add_0x_prefix(cls.bytecode)
+            deploy_data = to_hex(cls.bytecode)
 
         return deploy_data
 

--- a/web3/middleware/pythonic.py
+++ b/web3/middleware/pythonic.py
@@ -320,7 +320,7 @@ pythonic_middleware = construct_formatting_middleware(
         'eth_getBlockByNumber': apply_formatter_if(block_formatter, is_not_null),
         'eth_getBlockTransactionCountByHash': to_integer_if_hex,
         'eth_getBlockTransactionCountByNumber': to_integer_if_hex,
-        'eth_getCode': to_ascii_if_bytes,
+        'eth_getCode': HexBytes,
         'eth_getFilterChanges': filter_result_formatter,
         'eth_getFilterLogs': filter_result_formatter,
         'eth_getTransactionByBlockHashAndIndex': apply_formatter_if(


### PR DESCRIPTION
### What was wrong?

eth.getCode was returning hex strings, see #340 

### How was it fixed?

Return HexBytes instead. Also store bytecode and bytecode_runtime as HexBytes

#### Cute Animal Picture

![Cute animal picture](https://i.pinimg.com/736x/99/15/be/9915bee01fa6d0f91bf4615626c4baf0--llama-unicorn-baby-llama.jpg)
