### PR TITLE
Return bytes from sign, getStorageAt

### DIFF
--- a/web3/middleware/pythonic.py
+++ b/web3/middleware/pythonic.py
@@ -296,6 +296,7 @@ pythonic_middleware = construct_formatting_middleware(
         'eth_getUncleCountByBlockHash': format_abi_parameters(['bytes32']),
         'eth_getUncleCountByBlockNumber': apply_formatter_at_index(block_number_formatter, 0),
         'eth_newFilter': apply_formatter_at_index(filter_params_formatter, 0),
+        'eth_sign': format_abi_parameters(['address', 'bytes']),
         'eth_sendTransaction': apply_formatter_at_index(transaction_params_formatter, 0),
         'eth_estimateGas': apply_formatter_at_index(transaction_params_formatter, 0),
         # personal
@@ -323,6 +324,7 @@ pythonic_middleware = construct_formatting_middleware(
         'eth_getCode': to_ascii_if_bytes,
         'eth_getFilterChanges': filter_result_formatter,
         'eth_getFilterLogs': filter_result_formatter,
+        'eth_getStorageAt': HexBytes,
         'eth_getTransactionByBlockHashAndIndex': apply_formatter_if(
             transaction_formatter,
             is_not_null,
@@ -346,6 +348,7 @@ pythonic_middleware = construct_formatting_middleware(
         ),
         'eth_sendRawTransaction': to_hexbytes(32),
         'eth_sendTransaction': to_hexbytes(32),
+        'eth_sign': HexBytes,
         'eth_syncing': apply_formatter_if(syncing_formatter, is_not_false),
         # SHH
         'shh_version': to_integer_if_hex,

--- a/web3/utils/module_testing/eth_module.py
+++ b/web3/utils/module_testing/eth_module.py
@@ -8,13 +8,13 @@ from eth_abi import (
 
 from eth_utils import (
     is_address,
+    is_bytes,
     is_string,
     is_boolean,
     is_dict,
     is_integer,
     is_list_like,
     is_same_address,
-    remove_0x_prefix,
 )
 
 from web3.utils.datastructures import (
@@ -142,8 +142,8 @@ class EthModuleTest(object):
 
     def test_eth_sign(self, web3, unlocked_account):
         signature = web3.eth.sign(unlocked_account, text='Message tö sign. Longer than hash!')
-        assert is_string(signature)
-        assert len(remove_0x_prefix(signature)) == 130
+        assert is_bytes(signature)
+        assert len(signature) == 32 + 32 + 1
 
         # test other formats
         hexsign = web3.eth.sign(

--- a/web3/utils/normalizers.py
+++ b/web3/utils/normalizers.py
@@ -45,7 +45,7 @@ def abi_bytes_to_hex(abi_type, data):
     base, sub, arrlist = process_type(abi_type)
     if base == 'bytes' and not arrlist:
         bytes_data = hexstr_if_str(to_bytes, data)
-        if len(bytes_data) != int(sub):
+        if sub and len(bytes_data) != int(sub):
             raise ValueError(
                 "This value was expected to be %d bytes, but instead was %d: %r" % (
                     (sub, len(bytes_data), data)


### PR DESCRIPTION
### What was wrong?

eth.sign, eth.getStorageAt were returning hex strings. see #340 

### How was it fixed?

Return HexBytes instead.

Also, `abi_bytes_to_hex` now supports unlimited length `bytes` ABI types

#### Cute Animal Picture

![Cute animal picture](https://img00.deviantart.net/3acb/i/2012/241/3/e/rainbow_llama_unicorn_by_rin_at_aim-d5cws53.jpg)
