### PR TITLE
In v3, warn about filter deprecation

### DIFF
--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -28,6 +28,11 @@ and methods.
     method when this filter was created.
 
 
+.. warning:: Asynchrony Deprecation: Native asynchronous filtering is deprecated
+    in favor a simpler synchronous implementation. This deprecation includes the
+    following attributes: `callbacks`, `running`, and `stopped`. It will be removed
+    in version 4.
+
 .. py:attribute:: Filter.callbacks
 
     A list of callbacks that this filter will call with new entries.
@@ -57,6 +62,11 @@ and methods.
     Hook for subclasses to add additional programatic filtering.  The default
     implementation always returns ``True``.
 
+
+.. warning:: Asynchrony Deprecation: Native asynchronous filtering is deprecated
+    in favor a simpler synchronous implementation. This deprecation includes the
+    following attributes: `callbacks`, `running`, and `stopped`. It will be removed
+    in version 4.
 
 .. py:method:: Filter.watch(*callbacks)
 
@@ -116,6 +126,10 @@ Event Log Filters
 The :py:class::`LogFilter` class is used for all filters pertaining to event
 logs.  It exposes the following additional methods.
 
+
+.. warning:: Removal in next version:  ``LogFilter.get`` is deprecated in favor of
+    ``Filter.get_new_entries`` and ``Filter.get_all_entries``, which will replace
+    all ``LogFilter.get`` usages in version 4.
 
 .. py:method:: LogFilter.get(only_changes=True)
 

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -51,6 +51,7 @@ from web3.utils.abi import (
 )
 from web3.utils.decorators import (
     combomethod,
+    deprecated_for,
 )
 from web3.utils.empty import (
     empty,
@@ -332,6 +333,7 @@ class Contract(object):
         return cls._encode_abi(fn_abi, fn_arguments, data)
 
     @combomethod
+    @deprecated_for("an upcoming v4 method: eventFilter()")
     def on(self, event_name, filter_params=None, *callbacks):
         """
         Register a callback to be triggered on the appropriate events.
@@ -367,6 +369,7 @@ class Contract(object):
         return log_filter
 
     @combomethod
+    @deprecated_for("an upcoming v4 method: eventFilter()")
     def pastEvents(self, event_name, filter_params=None, *callbacks):
         """
         Register a callback to be triggered on all past events.

--- a/web3/utils/filters.py
+++ b/web3/utils/filters.py
@@ -1,5 +1,6 @@
 import re
 import random
+import warnings
 
 from eth_utils import (
     is_string,
@@ -93,6 +94,15 @@ class Filter(GreenletThread):
             else:
                 sleep(self.poll_interval)
 
+    def _warn_async_deprecated(self, method_name):
+        warnings.warn(DeprecationWarning(
+            "Asynchronous filters have been deprecated "
+            "and `{0}` will be removed from the Filter class "
+            "in future releases.  Prepare to update your code to work "
+            "synchronously or handle asynchrony explicitly with a "
+            "third party library, when switching to web3 version 4.".format(method_name)
+        ))
+
     def format_entry(self, entry):
         """
         Hook for subclasses to change the format of the value that is passed
@@ -107,6 +117,8 @@ class Filter(GreenletThread):
         return True
 
     def watch(self, *callbacks):
+        self._warn_async_deprecated("watch")
+
         if self.stopped:
             raise ValueError("Cannot watch on a filter that has been stopped")
         self.callbacks.extend(callbacks)
@@ -116,6 +128,8 @@ class Filter(GreenletThread):
         sleep(0)
 
     def stop_watching(self, timeout=0):
+        self._warn_async_deprecated("stop_watching")
+
         self.running = False
         self.stopped = True
         self.web3.eth.uninstallFilter(self.filter_id)
@@ -163,6 +177,13 @@ class LogFilter(Filter):
         super(LogFilter, self).__init__(*args, **kwargs)
 
     def get(self, only_changes=True):
+        warnings.warn(DeprecationWarning(
+            "LogFilter.get has been deprecated and "
+            "will be removed from the LogFilter class in future releases. "
+            "Update your code to use the new methods: "
+            "LogFilter.get_new_entries and LogFilter.get_all_entries."
+        ))
+
         if self.running:
             raise ValueError(
                 "Cannot call `get` on a filter object which is actively watching"
@@ -234,6 +255,8 @@ class ShhFilter(Filter):
                 sleep(self.poll_interval)
 
     def stop_watching(self, timeout=0):
+        self._warn_async_deprecated("stop_watching")
+
         self.running = False
         self.stopped = True
         self.web3.shh.uninstallFilter(self.filter_id)


### PR DESCRIPTION
### What was wrong?

Filter synchronous usage will be removed in v4

### How was it fixed?

Backported the in-code warnings and documentation warnings. Will close #400 

#### Cute Animal Picture

![Cute animal picture](https://pbs.twimg.com/media/CuxUbVDUAAALdgA.jpg)