### PR TITLE
Remove shh default module, add docs warning

### DIFF
--- a/docs/web3.shh.rst
+++ b/docs/web3.shh.rst
@@ -7,6 +7,11 @@ SHH API
 The ``web3.shh`` object exposes methods to interact with the RPC APIs under the
 ``shh_`` namespace.
 
+.. warning:: The Whisper protocol is in flux, with incompatible versions supported
+    by different major clients. So it is not currently included by default in the web3
+    instance.
+
+
 Properties
 ----------
 

--- a/web3/main.py
+++ b/web3/main.py
@@ -18,7 +18,6 @@ from web3.iban import Iban
 from web3.miner import Miner
 from web3.net import Net
 from web3.personal import Personal
-from web3.shh import Shh
 from web3.testing import Testing
 from web3.txpool import TxPool
 from web3.version import Version
@@ -53,7 +52,6 @@ from web3.utils.encoding import (
 def get_default_modules():
     return {
         "eth": Eth,
-        "shh": Shh,
         "net": Net,
         "personal": Personal,
         "version": Version,


### PR DESCRIPTION
### What was wrong?

Whisper is too immature to include by default. It has different RPC APIs in the global wiki, geth, and parity.

### How was it fixed?

Remove it by default, add a warning in the docs. Closes #401 

#### Cute Animal Picture

![Cute animal picture](http://s3.amazonaws.com/cdn.roosterteeth.com/uploads/images/627635d2-2f85-4f3a-839b-1df082450992/md/_Damnation_4e3b2e664a944.jpg)
