### PR TITLE
Raise an explicit error if trying to use python 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,14 +55,11 @@ setup(
     keywords='ethereum',
     packages=find_packages(exclude=["tests", "tests.*"]),
     classifiers=[
-        'Development Status :: 2 - Pre-Alpha',
+        'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
     ],
 )

--- a/web3/__init__.py
+++ b/web3/__init__.py
@@ -1,17 +1,19 @@
-from __future__ import absolute_import
-
 import pkg_resources
+import sys
 
-from web3.account import Account
-from web3.main import Web3
-from web3.providers.rpc import (
+if sys.version_info.major < 3:
+    raise EnvironmentError("Python 3 is required")
+
+from web3.account import Account  # noqa: E402
+from web3.main import Web3  # noqa: E402
+from web3.providers.rpc import (  # noqa: E402
     HTTPProvider,
 )
-from web3.providers.tester import (
+from web3.providers.tester import (  # noqa: E402
     TestRPCProvider,
     EthereumTesterProvider,
 )
-from web3.providers.ipc import (
+from web3.providers.ipc import (  # noqa: E402
     IPCProvider,
 )
 


### PR DESCRIPTION
### What was wrong?

A surprising number of people build from source but use Python 2. They get unclear messages about weird little things that break in py2.

### How was it fixed?

Explicitly crash when trying to import web3 in python 2.

#### Cute Animal Picture

![Cute animal picture](http://www.takepart.com/sites/default/files/styles/tp_gallery_slide/public/SlowLoris1-itok=2PVT_ci7.jpg)