### PR TITLE
Adding implementation for eth_getLogs

### DIFF
--- a/web3/eth.py
+++ b/web3/eth.py
@@ -289,7 +289,9 @@ class Eth(Module):
         )
 
     def getLogs(self, filter_params):
-        raise NotImplementedError("Not yet implemented")
+        return self.web3.manager.request_blocking(
+            "eth_getLogs", [filter_params],
+        )
 
     def uninstallFilter(self, filter_id):
         return self.web3.manager.request_blocking(

--- a/web3/middleware/pythonic.py
+++ b/web3/middleware/pythonic.py
@@ -310,6 +310,7 @@ pythonic_middleware = construct_formatting_middleware(
         'eth_getUncleCountByBlockHash': format_abi_parameters(['bytes32']),
         'eth_getUncleCountByBlockNumber': apply_formatter_at_index(block_number_formatter, 0),
         'eth_newFilter': apply_formatter_at_index(filter_params_formatter, 0),
+        'eth_getLogs': apply_formatter_at_index(filter_params_formatter, 0),
         'eth_sign': format_abi_parameters(['address', 'bytes']),
         'eth_sendTransaction': apply_formatter_at_index(transaction_params_formatter, 0),
         'eth_estimateGas': apply_formatter_at_index(transaction_params_formatter, 0),


### PR DESCRIPTION
### What was wrong?
web3.eth.getLogs had a placeholder NotImplementedError raised when called.


### How was it fixed?
Followed the same pattern as similar requests, calling "eth_getLogs" from the provider.


#### Cute Animal Picture

![Cute animal picture](https://i.pinimg.com/736x/b4/85/5d/b4855d481fcb4503648638d9cf7d3c60--dog-halloween-halloween-costumes.jpg)
