### PR TITLE
Resolve HexBytes incompatibility issue on Python 2

### DIFF
--- a/web3/utils/datastructures.py
+++ b/web3/utils/datastructures.py
@@ -178,10 +178,10 @@ class NamedElementStack(Mapping):
 class HexBytes(bytes):
     def __new__(cls, val):
         bytesval = hexstr_if_str(to_bytes, val)
-        return super().__new__(cls, bytesval)
+        return super(HexBytes, cls).__new__(cls, bytesval)
 
     def hex(self):
-        return '0x' + super().hex()
+        return '0x' + super(HexBytes, self).hex()
 
     def __repr__(self):
         return 'HexBytes(%r)' % self.hex()


### PR DESCRIPTION
### What was wrong?
HexBytes would error when calling web3.eth.account.create(), this is an incompatibility issue on Python 2 since "super()" only works for Python 3.

### How was it fixed?
Expand super() to super(HexBytes, cls)

#### Cute Animal Picture
![My cookie is missing](https://user-images.githubusercontent.com/14210320/32633404-66e80db6-c575-11e7-811e-b4eacd90bdaf.jpg)
