### PR TITLE
Move personal module transforms to middleware

### DIFF
--- a/web3/middleware/pythonic.py
+++ b/web3/middleware/pythonic.py
@@ -26,6 +26,7 @@ from eth_utils import (
     is_bytes,
     is_list_like,
     encode_hex,
+    remove_0x_prefix,
 )
 
 from web3.utils.abi import (
@@ -33,6 +34,10 @@ from web3.utils.abi import (
 )
 from web3.utils.datastructures import (
     HexBytes,
+)
+from web3.utils.encoding import (
+    hexstr_if_str,
+    to_hex,
 )
 from web3.utils.formatters import (
     apply_formatter_if,
@@ -345,6 +350,10 @@ pythonic_middleware = construct_formatting_middleware(
         'eth_sendTransaction': apply_formatter_at_index(transaction_params_formatter, 0),
         'eth_estimateGas': apply_formatter_at_index(transaction_params_formatter, 0),
         # personal
+        'personal_importRawKey': apply_formatter_at_index(
+            compose(remove_0x_prefix, hexstr_if_str(to_hex)),
+            0,
+        ),
         'personal_sendTransaction': apply_formatter_at_index(transaction_params_formatter, 0),
         'personal_sign': apply_formatter_at_index(encode_hex, 0),
         'personal_ecRecover': apply_formatter_at_index(encode_hex, 0),
@@ -397,6 +406,9 @@ pythonic_middleware = construct_formatting_middleware(
         'eth_syncing': apply_formatter_if(is_not_false, syncing_formatter),
         # personal
         'personal_importRawKey': to_checksum_address,
+        'personal_listAccounts': apply_formatter_to_array(to_checksum_address),
+        'personal_newAccount': to_checksum_address,
+        'personal_sendTransaction': to_hexbytes(32),
         # SHH
         'shh_getFilterChanges': apply_formatter_to_array(whisper_log_formatter),
         'shh_getMessages': apply_formatter_to_array(whisper_log_formatter),

--- a/web3/personal.py
+++ b/web3/personal.py
@@ -4,50 +4,28 @@ from web3.module import (
     Module,
 )
 
-from eth_utils import (
-    coerce_return_to_text,
-    remove_0x_prefix,
-    encode_hex,
-)
-
 
 class Personal(Module):
     """
     https://github.com/ethereum/go-ethereum/wiki/Management-APIs#personal
     """
-    @coerce_return_to_text
     def importRawKey(self, private_key, passphrase):
-        if len(private_key) == 66:
-            private_key = remove_0x_prefix(private_key)
-        elif len(private_key) == 32:
-            private_key = remove_0x_prefix(encode_hex(private_key))
-        elif len(private_key) == 64:
-            pass
-        else:
-            raise ValueError("Unknown private key format")
         return self.web3.manager.request_blocking(
             "personal_importRawKey",
             [private_key, passphrase],
         )
 
-    @coerce_return_to_text
     def newAccount(self, password):
         return self.web3.manager.request_blocking(
             "personal_newAccount", [password],
         )
 
     @property
-    @coerce_return_to_text
     def listAccounts(self):
         return self.web3.manager.request_blocking(
             "personal_listAccounts", [],
         )
 
-    @coerce_return_to_text
-    def getListAccounts(self, *args, **kwargs):
-        raise NotImplementedError("Async calling has not been implemented")
-
-    @coerce_return_to_text
     def sendTransaction(self, transaction, passphrase):
         return self.web3.manager.request_blocking(
             "personal_sendTransaction",

--- a/web3/utils/module_testing/personal_module.py
+++ b/web3/utils/module_testing/personal_module.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
 from eth_utils import (
-    is_address,
+    is_checksum_address,
     is_list_like,
     is_same_address,
 )
@@ -26,7 +26,7 @@ class PersonalModuleTest(object):
         assert is_list_like(accounts)
         assert len(accounts) > 0
         assert all((
-            is_address(item)
+            is_checksum_address(item)
             for item
             in accounts
         ))
@@ -50,7 +50,7 @@ class PersonalModuleTest(object):
 
     def test_personal_newAccount(self, web3):
         new_account = web3.personal.newAccount(PASSWORD)
-        assert is_address(new_account)
+        assert is_checksum_address(new_account)
 
     def test_personal_sendTransaction(self,
                                       web3,
@@ -67,8 +67,8 @@ class PersonalModuleTest(object):
         txn_hash = web3.personal.sendTransaction(txn_params, unlockable_account_pw)
         assert txn_hash
         transaction = web3.eth.getTransaction(txn_hash)
-        assert is_same_address(transaction['from'], txn_params['from'])
-        assert is_same_address(transaction['to'], txn_params['to'])
+        assert transaction['from'] == txn_params['from']
+        assert transaction['to'] == txn_params['to']
         assert transaction['gas'] == txn_params['gas']
         assert transaction['value'] == txn_params['value']
         assert transaction['gasPrice'] == txn_params['gasPrice']


### PR DESCRIPTION
### What was wrong?

Cleanup and coercion was happening in the personal module. Some pieces weren't modernized for v4, like using checksum addresses, and returning HexBytes values.

### How was it fixed?

Remove all existing coercions, using middleware instead. Also, switch to comparing exact match on checksum address.

A full review is recommended for a later time, but geth and parity have not converged yet.

#### Cute Animal Picture

![Cute animal picture](https://www.hillwalktours.com/walking-hiking-blog/wp-content/uploads/2017/02/highland-cow-and-calf.jpg)
