### PR TITLE
Replace is_address checks with is_checksum_address

### DIFF
--- a/ens/main.py
+++ b/ens/main.py
@@ -1,6 +1,5 @@
 
 from eth_utils import (
-    is_address,
     is_checksum_address,
     to_checksum_address,
 )
@@ -184,10 +183,7 @@ class ENS:
         if resolver:
             lookup_function = getattr(resolver, get)
             namehash = name_to_hash(normal_name)
-            resolved = lookup_function(namehash)
-            if is_address(resolved):
-                resolved = to_checksum_address(resolved)
-            return resolved
+            return lookup_function(namehash)
         else:
             return None
 

--- a/tests/core/eth-module/test_accounts.py
+++ b/tests/core/eth-module/test_accounts.py
@@ -6,7 +6,7 @@ import pytest
 import sys
 
 from eth_utils import (
-    is_address,
+    is_checksum_address,
     is_hex,
 )
 
@@ -109,7 +109,7 @@ def test_eth_account_privateKeyToAccount_properties(web3, PRIVATE_BYTES):
     account = web3.eth.account.privateKeyToAccount(PRIVATE_BYTES)
     assert callable(account.sign)
     assert callable(account.signTransaction)
-    assert is_address(account.address)
+    assert is_checksum_address(account.address)
     assert account.address == '0xa79F6f349C853F9Ea0B29636779ae3Cb4E3BA729'
     assert account.privateKey == PRIVATE_BYTES
 
@@ -118,7 +118,7 @@ def test_eth_account_create_properties(web3):
     account = web3.eth.account.create()
     assert callable(account.sign)
     assert callable(account.signTransaction)
-    assert is_address(account.address)
+    assert is_checksum_address(account.address)
     if sys.version_info.major < 3:
         assert is_hex(account.privateKey) and len(account.privateKey) == 66
     else:

--- a/tests/generate_go_ethereum_fixture.py
+++ b/tests/generate_go_ethereum_fixture.py
@@ -16,7 +16,7 @@ from eth_utils import (
     to_wei,
     remove_0x_prefix,
     is_dict,
-    is_address,
+    is_checksum_address,
     is_same_address,
     force_text,
 )
@@ -284,7 +284,7 @@ def deploy_contract(web3, name, factory):
     deploy_receipt = mine_transaction_hash(web3, deploy_txn_hash)
     print('{0}_CONTRACT_DEPLOY_TRANSACTION_MINED'.format(name.upper()))
     contract_address = deploy_receipt['contractAddress']
-    assert is_address(contract_address)
+    assert is_checksum_address(contract_address)
     print('{0}_CONTRACT_ADDRESS:'.format(name.upper()), contract_address)
     return deploy_receipt
 

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -6,7 +6,7 @@ import sys
 import pytest
 
 from eth_utils import (
-    is_address,
+    is_checksum_address,
     is_dict,
 )
 
@@ -64,7 +64,7 @@ def math_contract(web3, math_contract_factory, math_contract_deploy_txn_hash):
     deploy_receipt = web3.eth.getTransactionReceipt(math_contract_deploy_txn_hash)
     assert is_dict(deploy_receipt)
     contract_address = deploy_receipt['contractAddress']
-    assert is_address(contract_address)
+    assert is_checksum_address(contract_address)
     return math_contract_factory(contract_address)
 
 
@@ -82,7 +82,7 @@ def emitter_contract(web3, emitter_contract_factory, emitter_contract_deploy_txn
     deploy_receipt = web3.eth.getTransactionReceipt(emitter_contract_deploy_txn_hash)
     assert is_dict(deploy_receipt)
     contract_address = deploy_receipt['contractAddress']
-    assert is_address(contract_address)
+    assert is_checksum_address(contract_address)
     return emitter_contract_factory(contract_address)
 
 

--- a/tests/integration/test_ethtestrpc.py
+++ b/tests/integration/test_ethtestrpc.py
@@ -4,7 +4,7 @@ import sys
 import pytest
 
 from eth_utils import (
-    is_address,
+    is_checksum_address,
     is_dict,
 )
 
@@ -50,7 +50,7 @@ def math_contract(web3, math_contract_factory, math_contract_deploy_txn_hash):
     deploy_receipt = web3.eth.getTransactionReceipt(math_contract_deploy_txn_hash)
     assert is_dict(deploy_receipt)
     contract_address = deploy_receipt['contractAddress']
-    assert is_address(contract_address)
+    assert is_checksum_address(contract_address)
     return math_contract_factory(contract_address)
 
 

--- a/tests/integration/test_goethereum.py
+++ b/tests/integration/test_goethereum.py
@@ -14,7 +14,7 @@ import pytest
 from eth_utils import (
     force_text,
     is_dict,
-    is_address,
+    is_checksum_address,
 )
 
 from web3 import Web3
@@ -230,7 +230,7 @@ def unlockable_account(web3, coinbase):
 @pytest.fixture(scope="session")
 def funded_account_for_raw_txn(geth_fixture_data):
     account = geth_fixture_data['raw_txn_account']
-    assert is_address(account)
+    assert is_checksum_address(account)
     return account
 
 

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -5,7 +5,7 @@ from cytoolz.dicttoolz import (
 )
 
 from eth_utils import (
-    is_address,
+    is_checksum_address,
     is_string,
 )
 
@@ -200,7 +200,7 @@ class Eth(Module):
 
     def sendTransaction(self, transaction):
         # TODO: move to middleware
-        if 'from' not in transaction and is_address(self.defaultAccount):
+        if 'from' not in transaction and is_checksum_address(self.defaultAccount):
             transaction = assoc(transaction, 'from', self.defaultAccount)
 
         # TODO: move gas estimation in middleware
@@ -230,7 +230,7 @@ class Eth(Module):
 
     def call(self, transaction, block_identifier=None):
         # TODO: move to middleware
-        if 'from' not in transaction and is_address(self.defaultAccount):
+        if 'from' not in transaction and is_checksum_address(self.defaultAccount):
             transaction = assoc(transaction, 'from', self.defaultAccount)
 
         # TODO: move to middleware
@@ -244,7 +244,7 @@ class Eth(Module):
 
     def estimateGas(self, transaction):
         # TODO: move to middleware
-        if 'from' not in transaction and is_address(self.defaultAccount):
+        if 'from' not in transaction and is_checksum_address(self.defaultAccount):
             transaction = assoc(transaction, 'from', self.defaultAccount)
 
         return self.web3.manager.request_blocking(

--- a/web3/utils/module_testing/eth_module.py
+++ b/web3/utils/module_testing/eth_module.py
@@ -9,7 +9,7 @@ from eth_abi import (
 )
 
 from eth_utils import (
-    is_address,
+    is_checksum_address,
     is_bytes,
     is_string,
     is_boolean,
@@ -55,7 +55,7 @@ class EthModuleTest(object):
 
     def test_eth_coinbase(self, web3):
         coinbase = web3.eth.coinbase
-        assert is_address(coinbase)
+        assert is_checksum_address(coinbase)
 
     def test_eth_mining(self, web3):
         mining = web3.eth.mining
@@ -76,7 +76,7 @@ class EthModuleTest(object):
         assert is_list_like(accounts)
         assert len(accounts) != 0
         assert all((
-            is_address(account)
+            is_checksum_address(account)
             for account
             in accounts
         ))


### PR DESCRIPTION
### What was wrong?

Some non-checksum addresses might have slipped through.

### How was it fixed?

Grepped for all `is_address` usages, and replaced (nearly) all of them.

Note that this changes the meaning of `Web3.isAddress`. Since we now require checksummed addresses everywhere, and return them everywhere, `isAddress` is now semantically the same as `isChecksumAddress`.

#### Cute Animal Picture

![Cute animal picture](https://i.pinimg.com/236x/e8/fc/f3/e8fcf31f09f533614e77803b3e7b3b8d--funny-things-funny-stuff.jpg)
