### PR TITLE
 Do not guess .eth ending for ENS names in web3

### DIFF
--- a/ens/main.py
+++ b/ens/main.py
@@ -27,6 +27,7 @@ from ens.utils import (
     init_web3,
     is_valid_name,
     label_to_hash,
+    name_to_hash,
     normalize_name,
 )
 
@@ -75,14 +76,19 @@ class ENS:
         '''
         return cls(web3.manager.providers, addr=addr)
 
-    def address(self, name):
+    def address(self, name, guess_tld=True):
         '''
         Look up the Ethereum address that `name` currently points to.
 
         :param str name: an ENS name to look up
+        :param bool guess_tld: should `name` be appended with '.eth' if no common TLD found?
         :raises InvalidName: if `name` has invalid syntax
         '''
-        return self.resolve(name, 'addr')
+        if guess_tld:
+            expanded = dot_eth_name(name)
+        else:
+            expanded = name
+        return self.resolve(expanded, 'addr')
 
     def name(self, address):
         '''
@@ -173,18 +179,20 @@ class ENS:
             return self._setup_reverse(name, address, transact=transact)
 
     def resolve(self, name, get='addr'):
-        resolver = self.resolver(name)
+        normal_name = normalize_name(name)
+        resolver = self.resolver(normal_name)
         if resolver:
             lookup_function = getattr(resolver, get)
-            resolved = lookup_function(dot_eth_namehash(name))
+            namehash = name_to_hash(normal_name)
+            resolved = lookup_function(namehash)
             if is_address(resolved):
                 resolved = to_checksum_address(resolved)
             return resolved
         else:
             return None
 
-    def resolver(self, name):
-        resolver_addr = self.ens.resolver(dot_eth_namehash(name))
+    def resolver(self, normal_name):
+        resolver_addr = self.ens.resolver(name_to_hash(normal_name))
         if not resolver_addr:
             return None
         return self._resolverContract(address=resolver_addr)
@@ -308,5 +316,5 @@ class ENS:
         return self._reverse_registrar().setName(name, transact=transact)
 
     def _reverse_registrar(self):
-        addr = self.ens.owner(dot_eth_namehash(REVERSE_REGISTRAR_DOMAIN))
+        addr = self.ens.owner(name_to_hash(REVERSE_REGISTRAR_DOMAIN))
         return self.web3.eth.contract(address=addr, abi=abis.REVERSE_REGISTRAR)

--- a/tests/ens/test_setup_name.py
+++ b/tests/ens/test_setup_name.py
@@ -65,8 +65,16 @@ def test_setup_name(ens, name, normalized_name, namehash_hex):
 
     ens.setup_name(name, address)
     assert ens.name(address) == normalized_name
+
+    # check that .eth is only appended if guess_tld is True
+    if ens.nameprep(name) != normalized_name:
+        assert ens.address(name, guess_tld=False) is None
+
+    # check that the correct namehash is set:
     node = Web3.toBytes(hexstr=namehash_hex)
-    assert ens.resolver(name).addr(node) == address
+    assert ens.resolver(normalized_name).addr(node) == address
+
+    # check that the correct owner is set:
     assert ens.owner(name) == owner
 
     ens.setup_name(None, address)

--- a/web3/utils/ens.py
+++ b/web3/utils/ens.py
@@ -23,7 +23,7 @@ def is_ens_name(value):
 
 
 def validate_name_has_address(ens, name):
-    addr = ens.address(name)
+    addr = ens.address(name, guess_tld=False)
     if addr:
         return addr
     else:
@@ -34,5 +34,7 @@ class StaticENS:
     def __init__(self, name_addr_pairs):
         self.registry = dict(name_addr_pairs)
 
-    def address(self, name):
+    def address(self, name, guess_tld=True):
+        # no automated web3 usages should be guessing the TLD
+        assert not guess_tld
         return self.registry.get(name, None)


### PR DESCRIPTION
### What was wrong?

If someone tried to use the name `xyz`, web3 would look up `xyz.eth` instead of the top level domain `xyz`. This leads to bad ambiguities when more & longer TLDs are added.

Closes #426 

### How was it fixed?

Never append .eth to names

* Added a strict version of ENS address lookup
* Exclusively use strict lookups in middleware & contracts

#### Cute Animal Picture

![Cute animal picture](https://www.bernedoodles.com/wp-content/uploads/SevenPuppies.jpg)