### PR TITLE
only test geth's that are byzantium-compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,20 +10,7 @@ matrix:
   include:
     # go-ethereum
     - python: "3.5"
-      env: TOX_POSARGS="-e py35-integration-goethereum" GETH_VERSION=v1.6.0
-    - python: "3.5"
-      env: TOX_POSARGS="-e py35-integration-goethereum" GETH_VERSION=v1.6.1
-    # 1.6.2 and 1.6.3 are failing due to go-ethereum internal errors.
-    - python: "3.5"
-      env: TOX_POSARGS="-e py35-integration-goethereum" GETH_VERSION=v1.6.4
-    - python: "3.5"
-      env: TOX_POSARGS="-e py35-integration-goethereum" GETH_VERSION=v1.6.5
-    - python: "3.5"
-      env: TOX_POSARGS="-e py35-integration-goethereum" GETH_VERSION=v1.6.6
-    - python: "3.5"
-      env: TOX_POSARGS="-e py35-integration-goethereum" GETH_VERSION=v1.6.7
-    - python: "3.5"
-      env: TOX_POSARGS="-e py35-integration-goethereum" GETH_VERSION=v1.7.0
+      env: TOX_POSARGS="-e py35-integration-goethereum" GETH_VERSION=v1.7.2
     # ENS
     - python: "3.5"
       env: TOX_POSARGS="-e py35-ens"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ ethereum>=1.6.1,<2.0
 flaky>=3.3.0
 flake8==3.4.1
 hypothesis>=3.31.2
-py-geth==1.10.1
+py-geth==1.10.2
 pytest>=3.2.1
 pytest-mock==1.*
 pytest-pythonpath>=0.3


### PR DESCRIPTION
### What was wrong?

Latest geth 1.7.2 was not tested

Cruft geth tests were slowing down travis

### How was it fixed?

Added 1.7.2 and removed old versions

~Blocking on https://github.com/pipermerriam/py-geth/pull/38~

Closes #421 

#### Cute Animal Picture

![Cute animal picture](http://www.petguide.com/wp-content/uploads/2016/04/doxiepoo-1.jpg)
