### PR TITLE
move ens_address context manager to web3.utils.ens

### DIFF
--- a/tests/core/contracts/test_contract_call_interface.py
+++ b/tests/core/contracts/test_contract_call_interface.py
@@ -8,7 +8,7 @@ from web3.exceptions import (
 from web3.utils.datastructures import (
     HexBytes,
 )
-from web3.middleware.names import (
+from web3.utils.ens import (
     contract_ens_addresses,
 )
 

--- a/tests/core/contracts/test_contract_init.py
+++ b/tests/core/contracts/test_contract_init.py
@@ -4,7 +4,7 @@ from web3.exceptions import (
     BadFunctionCallOutput,
     NameNotFound,
 )
-from web3.middleware.names import (
+from web3.utils.ens import (
     contract_ens_addresses,
 )
 

--- a/web3/middleware/names.py
+++ b/web3/middleware/names.py
@@ -1,9 +1,3 @@
-from contextlib import contextmanager
-
-from web3.utils.ens import (
-    StaticENS,
-)
-
 from web3.utils.normalizers import (
     abi_ens_resolver,
 )
@@ -24,19 +18,3 @@ def name_to_address_middleware(w3):
     return construct_formatting_middleware(
         request_formatters=abi_request_formatters(normalizers, RPC_ABIS)
     )
-
-
-@contextmanager
-def contract_ens_addresses(contract, name_addr_pairs):
-    '''
-    Use this context manager to temporarily resolve name/address pairs
-    supplied as the argument. For example:
-
-    with contract_ens_addresses(mycontract, [('resolve-as-1s.eth', '0x111...111')]):
-        # any contract call or transaction in here would only resolve the above ENS pair
-    '''
-    w3 = contract.web3
-    original_ens = w3.ens
-    w3.ens = StaticENS(name_addr_pairs)
-    yield
-    w3.ens = original_ens


### PR DESCRIPTION
### What was wrong?

`ens_address` contextmanager was in middleware module for historical reasons, it belongs in `web3.utils.ens`

### How was it fixed?

Moved it.

#### Cute Animal Picture

![Cute animal picture](https://i.pinimg.com/originals/75/44/c8/7544c8852c7934a03e7df6ba7c9a29bb.jpg)