### PR TITLE
Clean up exception code (#339)

### DIFF
--- a/web3/account.py
+++ b/web3/account.py
@@ -39,9 +39,6 @@ from web3.utils.encoding import (
     to_int,
     to_hex,
 )
-from web3.utils.exception import (
-    raise_from,
-)
 from web3.utils.signing import (
     LocalAccount,
     hash_of_signed_transaction,
@@ -98,13 +95,10 @@ class Account(object):
             key_obj = self._keys.PrivateKey(key_bytes)
             return LocalAccount(key_obj, self)
         except ValidationError as original_exception:
-            raise_from(
-                ValueError(
+            raise ValueError(
                     "The private key must be exactly 32 bytes long, instead of "
                     "%d bytes." % len(key_bytes)
-                ),
-                original_exception
-            )
+                ) from original_exception
 
     def recover(self, msghash, vrs=None, signature=None):
         hash_bytes = HexBytes(msghash)

--- a/web3/account.py
+++ b/web3/account.py
@@ -96,9 +96,9 @@ class Account(object):
             return LocalAccount(key_obj, self)
         except ValidationError as original_exception:
             raise ValueError(
-                    "The private key must be exactly 32 bytes long, instead of "
-                    "%d bytes." % len(key_bytes)
-                ) from original_exception
+                "The private key must be exactly 32 bytes long, instead of "
+                "%d bytes." % len(key_bytes)
+            ) from original_exception
 
     def recover(self, msghash, vrs=None, signature=None):
         hash_bytes = HexBytes(msghash)

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -62,9 +62,6 @@ from web3.utils.ens import (
 from web3.utils.events import (
     get_event_data,
 )
-from web3.utils.exception import (
-    raise_from,
-)
 from web3.utils.filters import (
     construct_event_filter_params,
 )
@@ -770,7 +767,7 @@ def call_contract_function(contract,
                     output_types
                 )
             )
-        raise_from(BadFunctionCallOutput(msg), e)
+        raise BadFunctionCallOutput(msg) from e
 
     normalizers = itertools.chain(
         BASE_RETURN_NORMALIZERS,

--- a/web3/utils/exception.py
+++ b/web3/utils/exception.py
@@ -1,4 +1,0 @@
-
-
-def raise_from(my_exception, other_exception):
-    raise my_exception from other_exception

--- a/web3/utils/exception.py
+++ b/web3/utils/exception.py
@@ -1,8 +1,4 @@
-import sys
 
 
-# raise MyException() from original_exception compatibility
-if sys.version_info.major == 2:
-    from .exception_py2 import raise_from  # noqa: F401
-else:
-    from .exception_py3 import raise_from  # noqa: F401
+def raise_from(my_exception, other_exception):
+    raise my_exception from other_exception

--- a/web3/utils/exception_py2.py
+++ b/web3/utils/exception_py2.py
@@ -1,5 +1,0 @@
-import sys
-
-
-def raise_from(my_exception, other_exception):
-    raise my_exception, None, sys.exc_info()[2]  # noqa: ignore=W602, E999

--- a/web3/utils/exception_py3.py
+++ b/web3/utils/exception_py3.py
@@ -1,2 +1,0 @@
-def raise_from(my_exception, other_exception):
-    raise my_exception from other_exception


### PR DESCRIPTION
### What was wrong?

Python 2 compatibility code is not needed anymore (#339).
