### PR TITLE
Look up ENS names in soliditySha3 'address' values

### DIFF
--- a/web3/main.py
+++ b/web3/main.py
@@ -39,8 +39,14 @@ from web3.manager import (
     RequestManager,
 )
 
+from web3.utils.abi import (
+    map_abi_data,
+)
 from web3.utils.datastructures import (
     HexBytes,
+)
+from web3.utils.decorators import (
+    combomethod,
 )
 from web3.utils.encoding import (
     hex_encode_abi_type,
@@ -48,6 +54,9 @@ from web3.utils.encoding import (
     to_int,
     to_hex,
     to_text,
+)
+from web3.utils.normalizers import (
+    abi_ens_resolver,
 )
 
 default = object()
@@ -132,7 +141,7 @@ class Web3(object):
             )
         )
 
-    @classmethod
+    @combomethod
     def soliditySha3(cls, abi_types, values):
         """
         Executes sha3 (keccak256) exactly as Solidity does.
@@ -145,10 +154,16 @@ class Web3(object):
                 "{0} types and {1} values.".format(len(abi_types), len(values))
             )
 
+        if isinstance(cls, type):
+            w3 = None
+        else:
+            w3 = cls
+        normalized_values = map_abi_data([abi_ens_resolver(w3)], abi_types, values)
+
         hex_string = add_0x_prefix(''.join(
             remove_0x_prefix(hex_encode_abi_type(abi_type, value))
             for abi_type, value
-            in zip(abi_types, values)
+            in zip(abi_types, normalized_values)
         ))
         return cls.sha3(hexstr=hex_string)
 

--- a/web3/utils/module_testing/web3_module.py
+++ b/web3/utils/module_testing/web3_module.py
@@ -1,10 +1,13 @@
 import pytest
 
+from web3 import Web3
+
 from web3.exceptions import (
     InvalidAddress,
 )
 
 from web3.utils.datastructures import HexBytes
+from web3.utils.ens import ens_addresses
 
 
 class Web3ModuleTest(object):
@@ -83,7 +86,6 @@ class Web3ModuleTest(object):
                 ],
                 HexBytes("0xd78a84d65721b67e4011b10c99dafdedcdcd7cb30153064f773e210b4762e22f"),
             ),
-
             (
                 ['string'],
                 ['testing a string!'],
@@ -167,6 +169,34 @@ class Web3ModuleTest(object):
 
         actual = web3.soliditySha3(types, values)
         assert actual == expected
+
+    @pytest.mark.parametrize(
+        'types, values, expected',
+        (
+            (
+                ['address'],
+                ['one.eth'],
+                HexBytes("0x2ff37b5607484cd4eecf6d13292e22bd6e5401eaffcc07e279583bc742c68882"),
+            ),
+            (
+                ['address[]'],
+                [['one.eth', 'two.eth']],
+                HexBytes("0xb98565c0c26a962fd54d93b0ed6fb9296e03e9da29d2281ed3e3473109ef7dde"),
+            ),
+        ),
+    )
+    def test_soliditySha3_ens(self, web3, types, values, expected):
+        with ens_addresses(web3, {
+            'one.eth': "0x49EdDD3769c0712032808D86597B84ac5c2F5614",
+            'two.eth': "0xA6b759bBbf4B59D24acf7E06e79f3a5D104fdCE5",
+        }):
+            # when called as class method, any name lookup attempt will fail
+            with pytest.raises(InvalidAddress):
+                Web3.soliditySha3(types, values)
+
+            # when called as instance method method, ens lookups can succeed
+            actual = web3.soliditySha3(types, values)
+            assert actual == expected
 
     @pytest.mark.parametrize(
         'types,values',

--- a/web3/utils/normalizers.py
+++ b/web3/utils/normalizers.py
@@ -14,6 +14,9 @@ from eth_utils import (
     to_checksum_address,
 )
 
+from web3.exceptions import (
+    InvalidAddress,
+)
 from web3.utils.encoding import (
     hexstr_if_str,
     text_if_str,
@@ -108,9 +111,9 @@ def abi_address_to_hex(abi_type, data):
 def abi_ens_resolver(w3, abi_type, val):
     if abi_type == 'address' and is_ens_name(val):
         if w3 is None:
-            raise ValueError("Could not look up name, because no web3 connection available")
+            raise InvalidAddress("Could not look up name, because no web3 connection available")
         elif w3.ens is None:
-            raise ValueError("Could not look up name, because ENS is set to None")
+            raise InvalidAddress("Could not look up name, because ENS is set to None")
         else:
             return (abi_type, validate_name_has_address(w3.ens, val))
     else:


### PR DESCRIPTION
### What was wrong?

`soliditySha3` fields with 'address' type were not attempting to look up ENS names.

### How was it fixed?

Converted the method to a combomethod so it can still be used as a classmethod, but if you want an ENS name lookup, you can call it as an instance method.

Ran the values through an ens lookup pipeline, contingent on abi type.

Raise a more specific `ValueError` when an ENS name is provided, but no connection is available: `InvalidAddress`.

New test to confirm lookups.

#### Cute Animal Picture

![Cute animal picture](https://i.pinimg.com/736x/8d/1a/ec/8d1aec55d1361dfbbf14902c63aa1ac0--chow-chow-puppies-puppys.jpg)