### PR TITLE
Accept ENS addresses directly to w3.eth.contract()

### DIFF
--- a/tests/core/contracts/test_contract_init.py
+++ b/tests/core/contracts/test_contract_init.py
@@ -6,6 +6,7 @@ from web3.exceptions import (
 )
 from web3.utils.ens import (
     contract_ens_addresses,
+    ens_addresses,
 )
 
 
@@ -27,6 +28,26 @@ def test_contract_with_unset_address(MathContract):
 def test_contract_with_name_address(MathContract, math_addr):
     with contract_ens_addresses(MathContract, [('thedao.eth', math_addr)]):
         mc = MathContract(address='thedao.eth')
+        caller = mc.web3.eth.coinbase
+        assert mc.address == 'thedao.eth'
+        assert mc.call({'from': caller}).return13() == 13
+
+
+def test_contract_with_name_address_from_eth_contract(
+    web3,
+    MATH_ABI,
+    MATH_CODE,
+    MATH_RUNTIME,
+    math_addr,
+):
+    with ens_addresses(web3, [('thedao.eth', math_addr)]):
+        mc = web3.eth.contract(
+            address='thedao.eth',
+            abi=MATH_ABI,
+            bytecode=MATH_CODE,
+            bytecode_runtime=MATH_RUNTIME,
+        )
+
         caller = mc.web3.eth.coinbase
         assert mc.address == 'thedao.eth'
         assert mc.call({'from': caller}).return13() == 13

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -306,8 +306,6 @@ class Eth(Module):
         ContractFactory = ContractFactoryClass.factory(self.web3, **kwargs)
 
         if address:
-            validate_address(address)
-
             return ContractFactory(address)
         else:
             return ContractFactory

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -36,9 +36,6 @@ from web3.utils.filters import (
 from web3.utils.transactions import (
     get_buffered_gas_estimate,
 )
-from web3.utils.validation import (
-    validate_address,
-)
 
 
 class Eth(Module):


### PR DESCRIPTION
### What was wrong?

An extra `validate_address` in eth.py was incorrectly rejecting ENS names when a contract was created with `w3.eth.contract(address='name.eth')`

### How was it fixed?

Removed 'validate_address`, which was superfluous anyway.

#### Cute Animal Picture

![Cute animal picture](http://cdn.foodbeast.com.s3.amazonaws.com/content/wp-content/uploads/2012/10/dog-banana-costume.jpg)