### PR TITLE
Add docker-compose for running sandbox environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.6
+
+# Set up code directory
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+# Install Linux dependencies
+RUN apt-get update && apt-get install -y libssl-dev
+
+# Copy over requirements
+COPY setup.py .
+COPY README.md .
+COPY requirements-dev.txt .
+
+# Install python dependencies
+RUN pip install -r requirements-dev.txt
+RUN pip install -e .
+
+WORKDIR /code

--- a/README.md
+++ b/README.md
@@ -104,6 +104,38 @@ pip install -r requirements-dev.txt
 pip install -e .
 ```
 
+## Using Docker
+
+If you would like to develop and test inside a docker environment, use the *sandbox* container provided in the **docker-compose.yml** file.
+
+To start up the test environment, run:
+
+```
+docker-compose up -d
+```
+
+This will build a docker container set up with an environment to run the Python test code.  
+
+**Note: This container does not have `go-ethereum` installed, so you cannot run the go-ethereum test suite.**
+
+To run the Python tests from your local machine:
+
+```
+docker-compose exec sandbox bash -c 'pytest -n 4 -f -k "not goethereum"'
+```
+
+You can run arbitrary commands inside the docker container by using the `bash -c` prefix.
+
+```
+docker-compose exec sandbox bash -c ''
+```
+
+Or, if you would like to just open a session to the container, run:
+
+```
+docker-compose exec sandbox bash
+```
+
 ### Testing Setup
 
 During development, you might like to have tests run on every file save.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3'
+services:
+  sandbox:
+    build:
+      context: .
+    volumes:
+      - .:/code
+    command: tail -f /dev/null


### PR DESCRIPTION
Using this “sandbox” you can run everything inside of docker without
worrying about OS specific requirements.

### What was wrong?
Developing across different environments is a bit of a pain especially when dealing with linux and different python packages.  Using a sandbox docker-compose environment for testing makes this easier.


### How was it fixed?
Added support for sandbox testing inside a docker-compose container.


#### Cute Animal Picture

```
                                                 (\\( \
                                                  `.\-.)
                              _...._            _,-'   `-.
\                           ,'      `-._.---.,-'       .  \
 \`.                      ,'                               `.
  \ `-...__              /                           .   .:  y
   `._     ``--..__     /                           ,'`---._/
      `-._         ``--'                      |    /_
          `.._                   _            ;   <_ \
              `--.___             `.           `-._ \ \
                     `--<           `.     (\ _/)/ `.\/
                         \            \     `<a \  /_/
                          `.           ;      `._y
                            `--.      /    _../
                                \    /__..'
                                 ;  //
                                <   \\
                                 `.  \\
                                   `. \\_ __
                                     `.`-'  \\
```
