### PR TITLE
accept raw bytes to sendRawTransaction

### DIFF
--- a/web3/utils/module_testing/eth_module.py
+++ b/web3/utils/module_testing/eth_module.py
@@ -223,8 +223,9 @@ class EthModuleTest(object):
                 '0x1f80f8ab5f12a45be218f76404bda64d37270a6f4f86ededd0eb599f80548c13',
             ),
             (
-                HexBytes('0xf8648085174876e8008252089439eeed73fb1d3855e90cbd42f348b3d7b340aaa601801ba0ec1295f00936acd0c2cb90ab2cdaacb8bf5e11b3d9957833595aca9ceedb7aada05dfc8937baec0e26029057abd3a1ef8c505dca2cdc07ffacb046d090d2bea06a'),  # noqa: E501
-                '0x1f80f8ab5f12a45be218f76404bda64d37270a6f4f86ededd0eb599f80548c13',
+                # private key 0x3c2ab4e8f17a7dea191b8c991522660126d681039509dc3bb31af7c9bdb63518
+                HexBytes('0xf85f808082c35094d898d5e829717c72e7438bad593076686d7d164a80801ba005c2e99ecee98a12fbf28ab9577423f42e9e88f2291b3acc8228de743884c874a077d6bc77a47ad41ec85c96aac2ad27f05a039c4787fca8a1e5ee2d8c7ec1bb6a'),  # noqa: E501
+                '0x98eeadb99454427f6aad7b558bac13e9d225512a6f5e5c11cf48e8d4067e51b5',
             ),
         ]
     )

--- a/web3/utils/module_testing/eth_module.py
+++ b/web3/utils/module_testing/eth_module.py
@@ -215,12 +215,22 @@ class EthModuleTest(object):
         assert txn['gas'] == 21000
         assert txn['gasPrice'] == txn_params['gas_price']
 
-    def test_eth_sendRawTransaction(self, web3):
-        txn_hash = web3.eth.sendRawTransaction(
-            '0xf8648085174876e8008252089439eeed73fb1d3855e90cbd42f348b3d7b340aaa601801ba0ec1295f00936acd0c2cb90ab2cdaacb8bf5e11b3d9957833595aca9ceedb7aada05dfc8937baec0e26029057abd3a1ef8c505dca2cdc07ffacb046d090d2bea06a'  # noqa: E501
-        )
-        expected = HexBytes('0x1f80f8ab5f12a45be218f76404bda64d37270a6f4f86ededd0eb599f80548c13')
-        assert txn_hash == expected
+    @pytest.mark.parametrize(
+        'raw_transaction, expected_hash',
+        [
+            (
+                '0xf8648085174876e8008252089439eeed73fb1d3855e90cbd42f348b3d7b340aaa601801ba0ec1295f00936acd0c2cb90ab2cdaacb8bf5e11b3d9957833595aca9ceedb7aada05dfc8937baec0e26029057abd3a1ef8c505dca2cdc07ffacb046d090d2bea06a',  # noqa: E501
+                '0x1f80f8ab5f12a45be218f76404bda64d37270a6f4f86ededd0eb599f80548c13',
+            ),
+            (
+                HexBytes('0xf8648085174876e8008252089439eeed73fb1d3855e90cbd42f348b3d7b340aaa601801ba0ec1295f00936acd0c2cb90ab2cdaacb8bf5e11b3d9957833595aca9ceedb7aada05dfc8937baec0e26029057abd3a1ef8c505dca2cdc07ffacb046d090d2bea06a'),  # noqa: E501
+                '0x1f80f8ab5f12a45be218f76404bda64d37270a6f4f86ededd0eb599f80548c13',
+            ),
+        ]
+    )
+    def test_eth_sendRawTransaction(self, web3, raw_transaction, expected_hash):
+        txn_hash = web3.eth.sendRawTransaction(raw_transaction)
+        assert txn_hash == web3.toBytes(hexstr=expected_hash)
 
     def test_eth_call(self, web3, math_contract):
         coinbase = web3.eth.coinbase

--- a/web3/utils/module_testing/eth_module.py
+++ b/web3/utils/module_testing/eth_module.py
@@ -224,6 +224,8 @@ class EthModuleTest(object):
             ),
             (
                 # private key 0x3c2ab4e8f17a7dea191b8c991522660126d681039509dc3bb31af7c9bdb63518
+                # This is an unfunded account, but the transaction has a 0 gas price, so is valid.
+                # It never needs to be mined, we just want the transaction hash back to confirm.
                 HexBytes('0xf85f808082c35094d898d5e829717c72e7438bad593076686d7d164a80801ba005c2e99ecee98a12fbf28ab9577423f42e9e88f2291b3acc8228de743884c874a077d6bc77a47ad41ec85c96aac2ad27f05a039c4787fca8a1e5ee2d8c7ec1bb6a'),  # noqa: E501
                 '0x98eeadb99454427f6aad7b558bac13e9d225512a6f5e5c11cf48e8d4067e51b5',
             ),

--- a/web3/utils/rpc_abi.py
+++ b/web3/utils/rpc_abi.py
@@ -30,10 +30,12 @@ FILTER_PARAMS_ABIS = {
 RPC_ABIS = {
     # eth
     'eth_call': TRANSACTION_PARAMS_ABIS,
+    'eth_estimateGas': TRANSACTION_PARAMS_ABIS,
     'eth_getBalance': ['address', None],
     'eth_getBlockByHash': ['bytes32', 'bool'],
     'eth_getBlockTransactionCountByHash': ['bytes32'],
     'eth_getCode': ['address', None],
+    'eth_getLogs': FILTER_PARAMS_ABIS,
     'eth_getStorageAt': ['address', 'uint', None],
     'eth_getTransactionByBlockHashAndIndex': ['bytes32', 'uint'],
     'eth_getTransactionByHash': ['bytes32'],
@@ -41,10 +43,9 @@ RPC_ABIS = {
     'eth_getTransactionReceipt': ['bytes32'],
     'eth_getUncleCountByBlockHash': ['bytes32'],
     'eth_newFilter': FILTER_PARAMS_ABIS,
-    'eth_getLogs': FILTER_PARAMS_ABIS,
-    'eth_sign': ['address', 'bytes'],
+    'eth_sendRawTransaction': ['bytes'],
     'eth_sendTransaction': TRANSACTION_PARAMS_ABIS,
-    'eth_estimateGas': TRANSACTION_PARAMS_ABIS,
+    'eth_sign': ['address', 'bytes'],
     # personal
     'personal_sendTransaction': TRANSACTION_PARAMS_ABIS,
 }


### PR DESCRIPTION
### What was wrong?

#440 

### How was it fixed?

Add an ABI definition for the ABI middleware, so the method will accept bytes or hex input.

#### Cute Animal Picture

![Cute animal picture](https://i.pinimg.com/236x/43/d0/4c/43d04cbbcdb6d8b8dfdcb299e7a3dcc0.jpg)
