### PR TITLE
Convert 'status' field from hex to int in getTransactionReceipt

### DIFF
--- a/web3/middleware/pythonic.py
+++ b/web3/middleware/pythonic.py
@@ -154,6 +154,7 @@ RECEIPT_FORMATTERS = {
     'transactionIndex': apply_formatter_if(is_not_null, to_integer_if_hex),
     'transactionHash': to_hexbytes(32),
     'cumulativeGasUsed': to_integer_if_hex,
+    'status': to_integer_if_hex,
     'gasUsed': to_integer_if_hex,
     'contractAddress': apply_formatter_if(is_not_null, to_checksum_address),
     'logs': apply_formatter_to_array(log_entry_formatter),


### PR DESCRIPTION
### What was wrong?
web3.eth.getTransactionReceipt returned a hex value for the status field. The status field was newly introduced following the Byzantium update. This was inconsistent with other returned values that were converted from hex to int.


### How was it fixed?
status was added to to the list of RECEIPT_FORMATTERS with a formatter of "to_integer_if_hex"


#### Cute Animal Picture

![Cute animal picture](https://i.pinimg.com/736x/2d/85/50/2d85501b342e5a182ed47dcd8a512e7a--cutest-animals-funny-animals.jpg)
