### PR TITLE
thread-aware check for recursive repeats

### DIFF
--- a/tests/core/compat-utils/test_spawn.py
+++ b/tests/core/compat-utils/test_spawn.py
@@ -1,11 +1,6 @@
 from web3.utils.compat.compat_stdlib import (
     spawn,
-    ThreadWithReturn,
 )
-
-
-class CustomThreadClass(ThreadWithReturn):
-    pass
 
 
 def test_spawning_simple_thread():
@@ -18,21 +13,5 @@ def test_spawning_simple_thread():
 
     thread = spawn(target_fn)
     thread.join()
-
-    assert container['success'] is True
-
-
-def test_spawning_specific_thread_class():
-    container = {
-        'success': None,
-    }
-
-    def target_fn():
-        container['success'] = True
-
-    thread = spawn(target_fn, thread_class=CustomThreadClass)
-    thread.join()
-
-    assert isinstance(thread, CustomThreadClass)
 
     assert container['success'] is True

--- a/tests/core/utilities/test_decorators.py
+++ b/tests/core/utilities/test_decorators.py
@@ -1,0 +1,21 @@
+from web3.utils.compat import (
+    sleep,
+    spawn,
+)
+from web3.utils.decorators import (
+    reject_recursive_repeats,
+)
+
+
+def test_reject_recursive_repeats_multithreaded():
+    @reject_recursive_repeats
+    def recurse(sleep_now):
+        sleep(sleep_now)
+        try:
+            recurse(0.05)
+            return True
+        except ValueError:
+            return False
+    thd1 = spawn(recurse, 0)
+    thd2 = spawn(recurse, 0.02)
+    assert thd2.get() and thd1.get()

--- a/web3/utils/compat/compat_gevent.py
+++ b/web3/utils/compat/compat_gevent.py
@@ -5,6 +5,7 @@ from gevent.pywsgi import (  # noqa: F401
     WSGIServer,
 )
 from gevent import (  # noqa: F401
+    getcurrent,
     subprocess,
     socket,
     threading,
@@ -23,6 +24,19 @@ _client_cache = pylru.lrucache(8)
 sleep = gevent.sleep
 spawn = gevent.spawn
 GreenletThread = gevent.Greenlet
+
+
+class ClassicThread(object):
+    def __init__(self, threadid):
+        self.ident = threadid
+
+
+def get_current_thread():
+    threadid = id(getcurrent())
+    return ClassicThread(threadid)
+
+
+threading.current_thread = get_current_thread
 
 
 class Timeout(gevent.Timeout):

--- a/web3/utils/compat/compat_stdlib.py
+++ b/web3/utils/compat/compat_stdlib.py
@@ -100,7 +100,7 @@ class ThreadWithReturn(threading.Thread):
             raise RuntimeError("Something went wrong.  No `_return` property was set")
 
 
-def spawn(target, thread_class=ThreadWithReturn, *args, **kwargs):
+def spawn(target, *args, thread_class=ThreadWithReturn, **kwargs):
     thread = thread_class(
         target=target,
         args=args,

--- a/web3/utils/compat/compat_stdlib.py
+++ b/web3/utils/compat/compat_stdlib.py
@@ -100,8 +100,8 @@ class ThreadWithReturn(threading.Thread):
             raise RuntimeError("Something went wrong.  No `_return` property was set")
 
 
-def spawn(target, *args, thread_class=ThreadWithReturn, **kwargs):
-    thread = thread_class(
+def spawn(target, *args, **kwargs):
+    thread = ThreadWithReturn(
         target=target,
         args=args,
         kwargs=kwargs,

--- a/web3/utils/decorators.py
+++ b/web3/utils/decorators.py
@@ -29,12 +29,13 @@ def reject_recursive_repeats(to_wrap):
     @functools.wraps(to_wrap)
     def wrapped(*args):
         arg_instances = tuple(map(id, args))
-        unique_call = (threading.current_thread().ident,) + arg_instances
-        if unique_call in to_wrap.__already_called:
+        thread_id = threading.current_thread().ident
+        thread_local_args = (thread_id,) + arg_instances
+        if thread_local_args in to_wrap.__already_called:
             raise ValueError('Recursively called %s with %r' % (to_wrap, args))
-        to_wrap.__already_called[unique_call] = True
+        to_wrap.__already_called[thread_local_args] = True
         wrapped_val = to_wrap(*args)
-        del to_wrap.__already_called[unique_call]
+        del to_wrap.__already_called[thread_local_args]
         return wrapped_val
     return wrapped
 

--- a/web3/utils/decorators.py
+++ b/web3/utils/decorators.py
@@ -1,6 +1,10 @@
 import functools
 import warnings
 
+from web3.utils.compat import (
+    threading,
+)
+
 
 class combomethod(object):
     def __init__(self, method):
@@ -24,12 +28,13 @@ def reject_recursive_repeats(to_wrap):
 
     @functools.wraps(to_wrap)
     def wrapped(*args):
-        instances = tuple(map(id, args))
-        if instances in to_wrap.__already_called:
+        arg_instances = tuple(map(id, args))
+        unique_call = (threading.get_ident(),) + arg_instances
+        if unique_call in to_wrap.__already_called:
             raise ValueError('Recursively called %s with %r' % (to_wrap, args))
-        to_wrap.__already_called[instances] = True
+        to_wrap.__already_called[unique_call] = True
         wrapped_val = to_wrap(*args)
-        del to_wrap.__already_called[instances]
+        del to_wrap.__already_called[unique_call]
         return wrapped_val
     return wrapped
 

--- a/web3/utils/decorators.py
+++ b/web3/utils/decorators.py
@@ -29,7 +29,7 @@ def reject_recursive_repeats(to_wrap):
     @functools.wraps(to_wrap)
     def wrapped(*args):
         arg_instances = tuple(map(id, args))
-        unique_call = (threading.get_ident(),) + arg_instances
+        unique_call = (threading.current_thread().ident,) + arg_instances
         if unique_call in to_wrap.__already_called:
             raise ValueError('Recursively called %s with %r' % (to_wrap, args))
         to_wrap.__already_called[unique_call] = True


### PR DESCRIPTION
### What was wrong?

`reject_recursive_repeats` was not thread-aware. It was causing false-positive exceptions in multithreaded environments.

### How was it fixed?

* only check for recursive repeats in the current thread, using `threading.get_ident()`
* `spawn` accepted custom thread classes, but wouldn't accept positional args without specifying the thread class. The api to specify custom thread class isn't compatible with gevent, and it wasn't used anywhere in web3, so I removed it.
* added a test to prevent regressions

Fixes #443 

#### Cute Animal Picture

![Cute animal picture](https://i.pinimg.com/originals/2c/89/ff/2c89ffa16463f3aaf171f9bd177f144f.jpg)
