### PR TITLE
V3 - Convert status field from hex to int in getTransactionReceipt

### DIFF
--- a/web3/middleware/pythonic.py
+++ b/web3/middleware/pythonic.py
@@ -115,6 +115,7 @@ RECEIPT_FORMATTERS = {
     'transactionIndex': apply_formatter_if(to_integer_if_hex, is_not_null),
     'transactionHash': to_ascii_if_bytes,
     'cumulativeGasUsed': to_integer_if_hex,
+    'status': to_integer_if_hex,
     'gasUsed': to_integer_if_hex,
     'contractAddress': apply_formatter_if(to_checksum_address, is_not_null),
     'logs': apply_formatter_to_array(log_entry_formatter),


### PR DESCRIPTION
### What was wrong?
web3.eth.getTransactionReceipt returned a hex value for the status field. The status field was newly introduced following the Byzantium update. This was inconsistent with other returned values that were converted from hex to int.


### How was it fixed?
status was added to to the list of RECEIPT_FORMATTERS with a formatter of "to_integer_if_hex"


#### Cute Animal Picture

![Cute animal picture](https://camo.githubusercontent.com/cac43f012b1337662e9f169551929985a21de8f8/68747470733a2f2f692e70696e696d672e636f6d2f373336782f32642f38352f35302f32643835353031623334326535613138326564343764636438613531326537612d2d6375746573742d616e696d616c732d66756e6e792d616e696d616c732e6a7067)
