### PR TITLE
eth.account: return hash of *signed* transaction

### DIFF
--- a/tests/core/eth-module/test_accounts.py
+++ b/tests/core/eth-module/test_accounts.py
@@ -271,7 +271,7 @@ def test_eth_account_sign(web3, message, key, expected_bytes, expected_hash, v, 
             },
             '0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318',
             HexBytes('0xf86a8086d55698372431831e848094f0109fc8df283027b6285cc889f5aa624eac1f55843b9aca008025a009ebb6ca057a0535d6186462bc0b465b561c94a295bdb0621fc19208ab149a9ca0440ffd775ce91a833ab410777204d5341a6f9fa91216a6f3ee2c051fea6a0428'),  # noqa: E501
-            HexBytes('0x6893a6ee8df79b0f5d64a180cd1ef35d030f3e296a5361cf04d02ce720d32ec5'),
+            HexBytes('0xd8f64a42b57be0d565f385378db2f6bf324ce14a594afc05de90436e9ce01f60'),
             HexBytes('0x09ebb6ca057a0535d6186462bc0b465b561c94a295bdb0621fc19208ab149a9c'),
             HexBytes('0x440ffd775ce91a833ab410777204d5341a6f9fa91216a6f3ee2c051fea6a0428'),
             37,

--- a/web3/account.py
+++ b/web3/account.py
@@ -165,9 +165,10 @@ class Account(object):
             v,
             r,
             s,
-            transaction_hash,
             rlp_encoded,
         ) = sign_transaction_dict(account._key_obj, transaction_dict)
+
+        transaction_hash = keccak(rlp_encoded)
 
         return AttributeDict({
             'rawTransaction': HexBytes(rlp_encoded),

--- a/web3/utils/signing.py
+++ b/web3/utils/signing.py
@@ -40,7 +40,7 @@ def sign_transaction_dict(eth_key, transaction_dict):
     # serialize transaction with rlp
     encoded_transaction = encode_transaction(unsigned_transaction, vrs=(v, r, s))
 
-    return (v, r, s, transaction_hash, encoded_transaction)
+    return (v, r, s, encoded_transaction)
 
 
 # watch here for updates to signature format: https://github.com/ethereum/EIPs/issues/191


### PR DESCRIPTION
### What was wrong?

When w3.eth.account signed a transaction, it returned a field `hash` which was the hash of the unsigned transaction.

### How was it fixed?

Return the hash of the signed transaction instead. I don't know of common cases where the hash of the unsigned transaction is necessary.

#### Cute Animal Picture

![Cute animal picture](http://www.allhatnocattle.net/halloween_doggie.jpg)
