### PR TITLE
Use Account without w3 instance

### DIFF
--- a/tests/core/eth-module/test_accounts.py
+++ b/tests/core/eth-module/test_accounts.py
@@ -8,6 +8,10 @@ from eth_utils import (
     is_hex,
 )
 
+from web3 import (
+    Account,
+)
+
 from web3.utils.datastructures import HexBytes
 from web3.utils.encoding import (
     to_bytes,
@@ -73,38 +77,47 @@ def web3js_password():
     return 'test!'
 
 
-def test_eth_account_create_variation(web3):
-    account1 = web3.eth.account.create()
-    account2 = web3.eth.account.create()
+@pytest.fixture(params=['instance', 'class'])
+def acct(request, web3):
+    if request.param == 'instance':
+        return web3.eth.account
+    elif request.param == 'class':
+        return Account
+    raise Exception('Unreachable!')
+
+
+def test_eth_account_create_variation(acct):
+    account1 = acct.create()
+    account2 = acct.create()
     assert account1 != account2
 
 
-def test_eth_account_privateKeyToAccount_reproducible(web3, PRIVATE_BYTES):
-    account1 = web3.eth.account.privateKeyToAccount(PRIVATE_BYTES)
-    account2 = web3.eth.account.privateKeyToAccount(PRIVATE_BYTES)
+def test_eth_account_privateKeyToAccount_reproducible(acct, PRIVATE_BYTES):
+    account1 = acct.privateKeyToAccount(PRIVATE_BYTES)
+    account2 = acct.privateKeyToAccount(PRIVATE_BYTES)
     assert bytes(account1) == PRIVATE_BYTES
     assert bytes(account1) == bytes(account2)
     assert isinstance(str(account1), str)
 
 
-def test_eth_account_privateKeyToAccount_diverge(web3, PRIVATE_BYTES, PRIVATE_BYTES_ALT):
-    account1 = web3.eth.account.privateKeyToAccount(PRIVATE_BYTES)
-    account2 = web3.eth.account.privateKeyToAccount(PRIVATE_BYTES_ALT)
+def test_eth_account_privateKeyToAccount_diverge(acct, PRIVATE_BYTES, PRIVATE_BYTES_ALT):
+    account1 = acct.privateKeyToAccount(PRIVATE_BYTES)
+    account2 = acct.privateKeyToAccount(PRIVATE_BYTES_ALT)
     assert bytes(account2) == PRIVATE_BYTES_ALT
     assert bytes(account1) != bytes(account2)
 
 
-def test_eth_account_privateKeyToAccount_seed_restrictions(web3):
+def test_eth_account_privateKeyToAccount_seed_restrictions(acct):
     with pytest.raises(ValueError):
-        web3.eth.account.privateKeyToAccount(b'')
+        acct.privateKeyToAccount(b'')
     with pytest.raises(ValueError):
-        web3.eth.account.privateKeyToAccount(b'\xff' * 31)
+        acct.privateKeyToAccount(b'\xff' * 31)
     with pytest.raises(ValueError):
-        web3.eth.account.privateKeyToAccount(b'\xff' * 33)
+        acct.privateKeyToAccount(b'\xff' * 33)
 
 
-def test_eth_account_privateKeyToAccount_properties(web3, PRIVATE_BYTES):
-    account = web3.eth.account.privateKeyToAccount(PRIVATE_BYTES)
+def test_eth_account_privateKeyToAccount_properties(acct, PRIVATE_BYTES):
+    account = acct.privateKeyToAccount(PRIVATE_BYTES)
     assert callable(account.sign)
     assert callable(account.signTransaction)
     assert is_checksum_address(account.address)
@@ -112,8 +125,8 @@ def test_eth_account_privateKeyToAccount_properties(web3, PRIVATE_BYTES):
     assert account.privateKey == PRIVATE_BYTES
 
 
-def test_eth_account_create_properties(web3):
-    account = web3.eth.account.create()
+def test_eth_account_create_properties(acct):
+    account = acct.create()
     assert callable(account.sign)
     assert callable(account.signTransaction)
     assert is_checksum_address(account.address)
@@ -123,26 +136,26 @@ def test_eth_account_create_properties(web3):
         assert isinstance(account.privateKey, bytes) and len(account.privateKey) == 32
 
 
-def test_eth_account_recover_transaction_example(web3):
+def test_eth_account_recover_transaction_example(acct):
     raw_tx_hex = '0xf8640d843b9aca00830e57e0945b2063246f2191f18f2675cedb8b28102e957458018025a00c753084e5a8290219324c1a3a86d4064ded2d15979b1ea790734aaa2ceaafc1a0229ca4538106819fd3a5509dd383e8fe4b731c6870339556a5c06feb9cf330bb'  # noqa: E501
-    from_account = web3.eth.account.recoverTransaction(raw_tx_hex)
+    from_account = acct.recoverTransaction(raw_tx_hex)
     assert from_account == '0xFeC2079e80465cc8C687fFF9EE6386ca447aFec4'
 
 
-def test_eth_account_recover_transaction_with_literal(web3):
+def test_eth_account_recover_transaction_with_literal(acct):
     raw_tx = 0xf8640d843b9aca00830e57e0945b2063246f2191f18f2675cedb8b28102e957458018025a00c753084e5a8290219324c1a3a86d4064ded2d15979b1ea790734aaa2ceaafc1a0229ca4538106819fd3a5509dd383e8fe4b731c6870339556a5c06feb9cf330bb  # noqa: E501
-    from_account = web3.eth.account.recoverTransaction(raw_tx)
+    from_account = acct.recoverTransaction(raw_tx)
     assert from_account == '0xFeC2079e80465cc8C687fFF9EE6386ca447aFec4'
 
 
-def test_eth_account_recover_message(web3):
+def test_eth_account_recover_message(acct):
     v, r, s = (
         28,
         '0xe6ca9bba58c88611fad66a6ce8f996908195593807c4b38bd528d2cff09d4eb3',
         '0x3e5bfbbf4d3e39b1a2fd816a7680c19ebebaf3a141b239934ad43cb33fcec8ce',
     )
     message = "I♥SF"
-    from_account = web3.eth.account.recoverMessage(text=message, vrs=(v, r, s))
+    from_account = acct.recoverMessage(text=message, vrs=(v, r, s))
     assert from_account == '0x5ce9454909639D2D17A3F753ce7d93fa0b9aB12E'
 
 
@@ -155,15 +168,15 @@ def test_eth_account_recover_message(web3):
         b'\x0cu0\x84\xe5\xa8)\x02\x192L\x1a:\x86\xd4\x06M\xed-\x15\x97\x9b\x1e\xa7\x90sJ\xaa,\xea\xaf\xc1"\x9c\xa4S\x81\x06\x81\x9f\xd3\xa5P\x9d\xd3\x83\xe8\xfeKs\x1chp3\x95V\xa5\xc0o\xeb\x9c\xf30\xbb\x1b',  # noqa: E501
     ]
 )
-def test_eth_account_recover_signature_bytes(web3, signature_bytes):
+def test_eth_account_recover_signature_bytes(acct, signature_bytes):
     msg_hash = b'\xbb\r\x8a\xba\x9f\xf7\xa1<N,s{i\x81\x86r\x83{\xba\x9f\xe2\x1d\xaa\xdd\xb3\xd6\x01\xda\x00\xb7)\xa1'  # noqa: E501
     msg_hash = to_hex_if_py2(msg_hash)
     signature = to_hex_if_py2(signature_bytes)
-    from_account = web3.eth.account.recover(msg_hash, signature=signature)
+    from_account = acct.recover(msg_hash, signature=signature)
     assert from_account == '0xFeC2079e80465cc8C687fFF9EE6386ca447aFec4'
 
 
-def test_eth_account_recover_vrs(web3):
+def test_eth_account_recover_vrs(acct):
     v, r, s = (
         27,
         5634810156301565519126305729385531885322755941350706789683031279718535704513,
@@ -171,14 +184,14 @@ def test_eth_account_recover_vrs(web3):
     )
     msg_hash = b'\xbb\r\x8a\xba\x9f\xf7\xa1<N,s{i\x81\x86r\x83{\xba\x9f\xe2\x1d\xaa\xdd\xb3\xd6\x01\xda\x00\xb7)\xa1'  # noqa: E501
     msg_hash = to_hex_if_py2(msg_hash)
-    from_account = web3.eth.account.recover(msg_hash, vrs=(v, r, s))
+    from_account = acct.recover(msg_hash, vrs=(v, r, s))
     assert from_account == '0xFeC2079e80465cc8C687fFF9EE6386ca447aFec4'
 
-    from_account = web3.eth.account.recover(msg_hash, vrs=map(to_hex, (v, r, s)))
+    from_account = acct.recover(msg_hash, vrs=map(to_hex, (v, r, s)))
     assert from_account == '0xFeC2079e80465cc8C687fFF9EE6386ca447aFec4'
 
 
-def test_eth_account_recover_vrs_standard_v(web3):
+def test_eth_account_recover_vrs_standard_v(acct):
     v, r, s = (
         0,
         5634810156301565519126305729385531885322755941350706789683031279718535704513,
@@ -186,7 +199,7 @@ def test_eth_account_recover_vrs_standard_v(web3):
     )
     msg_hash = b'\xbb\r\x8a\xba\x9f\xf7\xa1<N,s{i\x81\x86r\x83{\xba\x9f\xe2\x1d\xaa\xdd\xb3\xd6\x01\xda\x00\xb7)\xa1'  # noqa: E501
     msg_hash = to_hex_if_py2(msg_hash)
-    from_account = web3.eth.account.recover(msg_hash, vrs=(v, r, s))
+    from_account = acct.recover(msg_hash, vrs=(v, r, s))
     assert from_account == '0xFeC2079e80465cc8C687fFF9EE6386ca447aFec4'
 
 
@@ -208,8 +221,8 @@ def test_eth_account_recover_vrs_standard_v(web3):
         ),
     ]
 )
-def test_eth_account_hash_message_text(web3, message, expected):
-    assert web3.eth.account.hashMessage(text=message) == expected
+def test_eth_account_hash_message_text(acct, message, expected):
+    assert acct.hashMessage(text=message) == expected
 
 
 @pytest.mark.parametrize(
@@ -225,8 +238,8 @@ def test_eth_account_hash_message_text(web3, message, expected):
         ),
     ]
 )
-def test_eth_account_hash_message_hexstr(web3, message, expected):
-    assert web3.eth.account.hashMessage(hexstr=message) == expected
+def test_eth_account_hash_message_hexstr(acct, message, expected):
+    assert acct.hashMessage(hexstr=message) == expected
 
 
 @pytest.mark.parametrize(
@@ -244,8 +257,8 @@ def test_eth_account_hash_message_hexstr(web3, message, expected):
         ),
     ),
 )
-def test_eth_account_sign(web3, message, key, expected_bytes, expected_hash, v, r, s, signature):
-    signed = web3.eth.account.sign(message_text=message, private_key=key)
+def test_eth_account_sign(acct, message, key, expected_bytes, expected_hash, v, r, s, signature):
+    signed = acct.sign(message_text=message, private_key=key)
     assert signed.message == expected_bytes
     assert signed.messageHash == expected_hash
     assert signed.v == v
@@ -253,7 +266,7 @@ def test_eth_account_sign(web3, message, key, expected_bytes, expected_hash, v, 
     assert signed.s == s
     assert signed.signature == signature
 
-    account = web3.eth.account.privateKeyToAccount(key)
+    account = acct.privateKeyToAccount(key)
     assert account.sign(message_text=message) == signed
 
 
@@ -278,15 +291,15 @@ def test_eth_account_sign(web3, message, key, expected_bytes, expected_hash, v, 
         ),
     ),
 )
-def test_eth_account_sign_transaction(web3, txn, private_key, expected_raw_tx, tx_hash, r, s, v):
-    signed = web3.eth.account.signTransaction(txn, private_key)
+def test_eth_account_sign_transaction(acct, txn, private_key, expected_raw_tx, tx_hash, r, s, v):
+    signed = acct.signTransaction(txn, private_key)
     assert signed.hash == tx_hash
     assert signed.r == r
     assert signed.s == s
     assert signed.v == v
     assert signed.rawTransaction == expected_raw_tx
 
-    account = web3.eth.account.privateKeyToAccount(private_key)
+    account = acct.privateKeyToAccount(private_key)
     assert account.signTransaction(txn) == signed
 
 
@@ -294,7 +307,7 @@ def test_eth_account_sign_transaction(web3, txn, private_key, expected_raw_tx, t
     'transaction',
     ETH_TEST_TRANSACTIONS,
 )
-def test_eth_account_sign_transaction_from_eth_test(web3, transaction):
+def test_eth_account_sign_transaction_from_eth_test(acct, transaction):
     expected_raw_txn = transaction['signed']
     key = transaction['key']
 
@@ -303,43 +316,43 @@ def test_eth_account_sign_transaction_from_eth_test(web3, transaction):
     # generated from the transaction hash and private key, mostly due to code
     # author's ignorance. The example test fixtures and implementations seem to agree, so far.
     # See ecdsa_raw_sign() in /eth_keys/backends/native/ecdsa.py
-    signed = web3.eth.account.signTransaction(transaction, key)
+    signed = acct.signTransaction(transaction, key)
     assert signed.r == HexBytes(expected_raw_txn[-130:-66])
 
     # confirm that signed transaction can be recovered to the sender
-    expected_sender = web3.eth.account.privateKeyToAccount(key).address
-    assert web3.eth.account.recoverTransaction(signed.rawTransaction) == expected_sender
+    expected_sender = acct.privateKeyToAccount(key).address
+    assert acct.recoverTransaction(signed.rawTransaction) == expected_sender
 
 
 @pytest.mark.parametrize(
     'transaction',
     ETH_TEST_TRANSACTIONS,
 )
-def test_eth_account_recover_transaction_from_eth_test(web3, transaction):
+def test_eth_account_recover_transaction_from_eth_test(acct, transaction):
     raw_txn = transaction['signed']
     key = transaction['key']
-    expected_sender = web3.eth.account.privateKeyToAccount(key).address
-    assert web3.eth.account.recoverTransaction(raw_txn) == expected_sender
+    expected_sender = acct.privateKeyToAccount(key).address
+    assert acct.recoverTransaction(raw_txn) == expected_sender
 
 
-def test_eth_account_encrypt(web3, web3js_key, web3js_password):
-    encrypted = web3.eth.account.encrypt(web3js_key, web3js_password)
+def test_eth_account_encrypt(acct, web3js_key, web3js_password):
+    encrypted = acct.encrypt(web3js_key, web3js_password)
 
     assert encrypted['address'] == '2c7536e3605d9c16a7a3d7b1898e529396a65c23'
     assert encrypted['version'] == 3
 
-    decrypted_key = web3.eth.account.decrypt(encrypted, web3js_password)
+    decrypted_key = acct.decrypt(encrypted, web3js_password)
 
     assert decrypted_key == to_bytes(hexstr=web3js_key)
 
 
-def test_eth_account_prepared_encrypt(web3, web3js_key, web3js_password):
-    account = web3.eth.account.privateKeyToAccount(web3js_key)
+def test_eth_account_prepared_encrypt(acct, web3js_key, web3js_password):
+    account = acct.privateKeyToAccount(web3js_key)
     encrypted = account.encrypt(web3js_password)
 
     assert encrypted['address'] == '2c7536e3605d9c16a7a3d7b1898e529396a65c23'
     assert encrypted['version'] == 3
 
-    decrypted_key = web3.eth.account.decrypt(encrypted, web3js_password)
+    decrypted_key = acct.decrypt(encrypted, web3js_password)
 
     assert decrypted_key == to_bytes(hexstr=web3js_key)

--- a/web3/account.py
+++ b/web3/account.py
@@ -32,6 +32,9 @@ from web3.utils.datastructures import (
     AttributeDict,
     HexBytes,
 )
+from web3.utils.decorators import (
+    combomethod,
+)
 from web3.utils.encoding import (
     hexstr_if_str,
     text_if_str,
@@ -57,6 +60,7 @@ from web3.utils.transactions import (
 class Account(object):
     _keys = keys
 
+    @combomethod
     def create(self, extra_entropy=''):
         extra_key_bytes = text_if_str(to_bytes, extra_entropy)
         key_bytes = keccak(os.urandom(32) + extra_key_bytes)
@@ -89,6 +93,7 @@ class Account(object):
         recovery_hasher = compose(HexBytes, keccak, signature_wrapper)
         return recovery_hasher(message_bytes)
 
+    @combomethod
     def privateKeyToAccount(self, private_key):
         key_bytes = HexBytes(private_key)
         try:
@@ -100,6 +105,7 @@ class Account(object):
                 "%d bytes." % len(key_bytes)
             ) from original_exception
 
+    @combomethod
     def recover(self, msghash, vrs=None, signature=None):
         hash_bytes = HexBytes(msghash)
         if vrs is not None:
@@ -115,10 +121,12 @@ class Account(object):
         pubkey = signature_obj.recover_public_key_from_msg_hash(hash_bytes)
         return pubkey.to_checksum_address()
 
+    @combomethod
     def recoverMessage(self, data=None, hexstr=None, text=None, vrs=None, signature=None):
         msg_hash = self.hashMessage(data, hexstr=hexstr, text=text)
         return self.recover(msg_hash, vrs=vrs, signature=signature)
 
+    @combomethod
     def recoverTransaction(self, serialized_transaction):
         txn_bytes = HexBytes(serialized_transaction)
         txn = Transaction.from_bytes(txn_bytes)
@@ -130,6 +138,7 @@ class Account(object):
     def setKeyBackend(self, backend):
         self._keys = KeyAPI(backend)
 
+    @combomethod
     def sign(self, message=None, private_key=None, message_hexstr=None, message_text=None):
         '''
         @param private_key in bytes, str, or int.
@@ -150,6 +159,7 @@ class Account(object):
             'signature': HexBytes(eth_signature_bytes),
         })
 
+    @combomethod
     def signTransaction(self, transaction_dict, private_key):
         '''
         @param private_key in bytes, str, or int.


### PR DESCRIPTION
### What was wrong?

Want to be able to call all Account methods statically, like:

```
from web3 import Account
acct = Account.create()
```

etc.

### How was it fixed?

* The `@combomethod` decorator on essentially every instance method in `Account`.
* Parametrize all tests to try both the instance and classmethod calls.

#### Cute Animal Picture

![Cute animal picture](http://static-32.sinclairstoryline.com/resources/media/e4d0a9f7-3e7f-4bc4-a5e0-db7db97e99bb-izzythechow3.PNG)
